### PR TITLE
SE-3475: adds terraform modules for simple OpenedX resources setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -2,10 +2,146 @@
 
 This repository holds our common Terraform Open edX deployment scripts.
 
-## TODOS:
+Currently it actually contains two different ways to provision AWS resources
 
+## First Approach
+
+Everything inside the `modules/openedx` folder.
+
+### TODOS:
+
+- Explanation of how to use these modules
 - `rds` and `s3` modules should be merged into the `application` module
 - Simplify configuration variables and remove *most deprecated settings* (check client requirements first)
 - Rename `application` to `openedx` and move `wordpress` to outside of the openedx directory
 - Automatically provision ACM certificates and domain names
 - Move VPC creation from `private-repo` to `openedx` module
+
+## Second Approach
+
+Pretty basic way of provisioning, it contains the following modules:
+
+- modules/email
+- modules/route53
+- modules/s3
+- modules/services/director
+- modules/services/elasticsearch
+- modules/services/mongodb
+- modules/services/openedx
+- modules/services/sql
+
+Please check each of those module folders to see what the module does.
+For a simple AWS OpenedX provisioning, you could reuse these modules on the following way:
+
+- One Terraform project with you'll only need to setup once (Route53, email):
+
+      provider "aws" {
+        region = <AWS Region>
+        ...
+      }
+
+      module "route53" {
+        source = "git@github.com:open-craft/terraform-scripts.git//modules/route53?ref=<LATEST RELEASE>"
+      
+        customer_domain = <CUSTOMER DOMAIN>
+      }
+
+      module "email" {
+        source = "git@github.com:open-craft/terraform-scripts.git//modules/email?ref=<LATEST RELEASE>"
+    
+        customer_domain = <CUSTOMER DOMAIN>
+        custom_emails_to_verify = <LIST OF EMAILS>
+        internal_emails = <LIST OF INTERNAL EMAILS>
+        route53_id = module.route53.route53_id
+    
+        customer_name = <CUSTOMER NAME>
+        environment = <CUSTOMER ENVIRONMENT>
+      }
+
+- And another one for all the resources used in conjunction with the OpenedX instance:
+
+      provider "aws" {
+        region = "<AWS Region>"
+        ...
+      }
+    
+      module "director" {
+        source = "git@github.com:open-craft/terraform-scripts.git//modules/services/director?ref=<LATEST RELEASE>"
+        director_key_pair_name = <AWS DIRECTOR KEY PAIR NAME>
+        image_id = <AWS DIRECTOR IMAGE ID>
+        instance_type = <AWS DIRECTOR INSTANCE TYPE>
+      }
+    
+      module "s3" {
+        source = "git@github.com:open-craft/terraform-scripts.git//modules/s3?ref=<LATEST RELEASE>"
+        customer_name = <CUSTOMER NAME>
+        environment = <CUSTOMER ENVIRONMENT>
+      }
+    
+      module "openedx" {
+        source = "git@github.com:open-craft/terraform-scripts.git//modules/services/openedx?ref=<LATEST RELEASE>"    
+        customer_name = <CUSTOMER NAME>
+        director_security_group_id = module.director.director_security_group_id
+        environment = <CUSTOMER ENVIRONMENT>
+        customer_domain = <CUSTOMER DOMAIN>
+      }
+    
+      module "sql" {
+        source = "git@github.com:open-craft/terraform-scripts.git//modules/services/sql?ref=<LATEST RELEASE>"
+    
+        customer_name = <CUSTOMER NAME>
+        environment = <CUSTOMER ENVIRONMENT>
+    
+        allocated_storage = <SQL ALLOCATED STORAGE>
+        database_root_username = <SQL ROOT USERNAME>
+        database_root_password = <SQL ROOT PASSWORD>
+    
+        edxapp_security_group_id = module.openedx.edxapp_security_group_id
+    
+        instance_class = <SQL INSTANCE CLASS>
+      }
+    
+      module "elasticsearch" {
+        source = "git@github.com:open-craft/terraform-scripts.git//modules/services/elasticsearch?ref=<LATEST RELEASE>"
+        customer_name = <CUSTOMER NAME>
+        edxapp_security_group_id = module.openedx.edxapp_security_group_id
+        environment = <CUSTOMER ENVIRONMENT>
+      }
+    
+      resource aws_instance edxapp {
+        ami = <AWS EDX IMAGE ID>
+        instance_type = <AWS EDX INSTANCE TYPE>
+        vpc_security_group_ids = [module.openedx.edxapp_security_group_id]
+    
+        root_block_device {
+          volume_size = 50        # setting only 50 GB for the edxapp disk space
+          volume_type = "gp2"
+        }
+    
+        key_name = <AWS EDX KEY PAIR NAME>
+    
+        tags = {
+          Name = "edxapp-1"  # keep adding resources and change the name
+        }
+      }
+    
+      // adding the edx instance into the load balancer
+      resource aws_lb_target_group_attachment edxapp {
+        target_group_arn = module.openedx.edxapp_lb_target_group_arn
+        target_id = aws_instance.edxapp.id
+        port = 80
+    
+        lifecycle {
+          create_before_destroy = true
+        }
+      }
+    
+      // adding the edx instance into the main domain load balancer
+      resource aws_lb_target_group_attachment "edxapp_main_domain" {
+        target_group_arn = module.openedx.edxapp_main_domain_lb_target_group_arn
+        target_id = aws_instance.edxapp.id
+        port = 80
+      }
+
+For more information on how to deploy an OpenedX instance with Terraform, please go
+to our internal [AWS terraform deployment tutorial](https://gitlab.com/opencraft/documentation/private/-/blob/master/howtos/aws/AWS_terraform_deployment_tutorial.md)

--- a/modules/email/README.md
+++ b/modules/email/README.md
@@ -1,0 +1,15 @@
+# AWS Emails Setup
+
+Here we are configuring SES, to be able for the OpenedX to send emails (and some to receive and test).
+
+## Input
+- `customer_domain`: Root domain deleted to Route53
+- `route53_id`: configured Route53 ID
+- `internal_emails`: List of emails to be used by the OpenedX instance (`no-reply` added as default)
+- `custom_emails_to_verify`: Test emails to be used as recipients until you get out of the sandbox (check *Note*)
+SES configuration to be out of the sandbox
+- `customer_name`
+- `environment`
+
+*Note*: After this being created, you need to login into AWS Console, go to SES and ask AWS to be
+out of the sandbox, so you can send emails from SES to anyone, and not only verified emails

--- a/modules/email/email.tf
+++ b/modules/email/email.tf
@@ -1,0 +1,85 @@
+resource aws_ses_domain_identity "primary" {
+  domain = var.customer_domain
+}
+
+resource aws_ses_domain_dkim "primary" {
+  domain = aws_ses_domain_identity.primary.domain
+}
+
+resource aws_route53_record "primary_ses_verification" {
+  zone_id = var.route53_id
+  name = "_amazonses.${aws_ses_domain_identity.primary.domain}"
+  type = "TXT"
+  ttl = "600"
+  records = [
+    aws_ses_domain_identity.primary.verification_token,
+  ]
+}
+
+resource aws_route53_record "primary_dkim_record" {
+  count = 3
+  zone_id = var.route53_id
+  name = "${element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}._domainkey.${aws_ses_domain_identity.primary.domain}"
+  type = "CNAME"
+  ttl = "600"
+  records = ["${element(aws_ses_domain_dkim.primary.dkim_tokens, count.index)}.dkim.amazonses.com"]
+}
+
+data "aws_region" "current" {}
+
+resource aws_route53_record "primary_email_receiving_record" {
+  name = var.customer_domain
+  type = "MX"
+  zone_id = var.route53_id
+  ttl = 1800
+  records = ["10 inbound-smtp.${data.aws_region.current.name}.amazonaws.com"]
+}
+
+resource aws_ses_domain_identity_verification "ses_verification" {
+  domain = aws_ses_domain_identity.primary.domain
+
+  depends_on = [
+    aws_route53_record.primary_ses_verification,
+    aws_route53_record.primary_dkim_record,
+  ]
+}
+
+resource aws_ses_email_identity "internal_emails" {
+  count = length(var.internal_emails)
+
+  email = "${var.internal_emails[count.index]}@${var.customer_domain}"
+}
+
+resource aws_ses_email_identity "verifiable_emails" {
+  count = length(var.custom_emails_to_verify)
+
+  email = var.custom_emails_to_verify[count.index]
+}
+
+resource aws_ses_receipt_rule_set "ses_rule_set" {
+  rule_set_name = "${var.customer_name}-${var.environment}-rule-set"
+}
+
+resource aws_ses_receipt_rule "ses_receipt_rule" {
+  name = "${var.customer_name}-${var.environment}-receipt-rule"
+  rule_set_name = aws_ses_receipt_rule_set.ses_rule_set.rule_set_name
+  recipients = [
+    for email_name in var.internal_emails : "${email_name}@${var.customer_domain}"
+  ]
+
+  enabled = true
+  scan_enabled = true
+
+  sns_action {
+    position = 1
+    topic_arn = aws_sns_topic.sns_set_topic.arn
+  }
+}
+
+resource aws_ses_active_receipt_rule_set "ses_active_receipt_rule_set" {
+  rule_set_name = aws_ses_receipt_rule_set.ses_rule_set.rule_set_name
+}
+
+resource aws_sns_topic "sns_set_topic" {
+  name = "${var.customer_name}-${var.environment}-sns-set-topic"
+}

--- a/modules/email/variables.tf
+++ b/modules/email/variables.tf
@@ -1,0 +1,22 @@
+variable "customer_domain" {
+  description = "domain or subdomain provided by a customer that delegates to Route53"
+}
+
+variable "route53_id" {
+  description = "route53 ID of the configured domain"
+}
+
+variable "internal_emails" {
+  description = "internal emails"
+  default = [
+    "no-reply"
+  ]
+}
+
+variable "custom_emails_to_verify" {
+  description = "external emails to verify and test initial email configuration, set at least your personal"
+  type = list(string)
+}
+
+variable "customer_name" {}
+variable "environment" {}

--- a/modules/route53/README.md
+++ b/modules/route53/README.md
@@ -1,0 +1,18 @@
+# AWS Route53 Setup
+
+Very simple placeholder, to initialize Route53 to be used by other modules (email, services/openedx)
+
+## Assumptions
+
+- The customer has agreed to delegate the domain/subdomain complete control (we'll need to provide Route53 nameservers)
+- The user will have to configure its DNS provider to point NS records to the provided nameservers
+
+## Input
+It only needs one variable:
+
+- `customer_domain`: domain or subdomain provided by a customer that delegates to Route53
+
+## Output
+
+- `route53_DNS`: Nameservers (to be provided to the client)
+- `route53_id`: TO be used by other modules 

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -1,0 +1,21 @@
+resource aws_route53_zone "primary" {
+  name = var.customer_domain
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# this was imported
+resource aws_acm_certificate "all_subdomains_certificate" {
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# this was imported
+resource aws_acm_certificate "main_domain_certificate" {
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/modules/route53/outputs.tf
+++ b/modules/route53/outputs.tf
@@ -1,0 +1,7 @@
+output "route53_DNS" {
+  value = aws_route53_zone.primary.name_servers
+}
+
+output "route53_id" {
+  value = aws_route53_zone.primary.id
+}

--- a/modules/route53/variables.tf
+++ b/modules/route53/variables.tf
@@ -1,0 +1,3 @@
+variable "customer_domain" {
+  description = "domain or subdomain provided by a customer that delegates to Route53"
+}

--- a/modules/s3/README.md
+++ b/modules/s3/README.md
@@ -1,0 +1,28 @@
+# AWS S3 Setup
+
+This module contains the S3 buckets necessary for the OpenedX instance to work. These are two
+separated buckets one for course storage and the other for tracking logs.
+
+## Input
+
+The following inputs are just for customization, they need to be provided, but they are not
+essential for the functioning of the module:
+
+- `customer_name`
+- `environment`: `prod` for example
+
+## Output
+
+Most of these output variables are necessary for the OpenedX installation/configuration, they should
+have to be added to the `vars.yml` file in the respective variables:
+
+- `s3_storage_bucket_name`: Name of the storage bucket, necessary for an OpenedX instance. To be set in the
+`EDXAPP_AWS_STORAGE_BUCKET_NAME` variable
+- `s3_storage_user_access_key`: Access Key ID for the created AWS user with the respective access to the
+`s3_storage_bucket_name` bucket. To be set in the `AWS_ACCESS_KEY_ID` variable
+- `s3_storage_user_secret_key`: Respective Secret Access Key to `s3_storage_user_access_key`. To be set
+in the `AWS_SECRET_ACCESS_KEY` variable
+- `s3_tracking_logs_bucket_name`: Name of the storage bucket, necessary for an OpenedX instance. To be set
+in the `COMMON_OBJECT_STORE_LOG_SYNC_BUCKET` variable
+- `s3_tracking_logs_user_access_key`: To be set in the `AWS_S3_LOGS_ACCESS_KEY_ID` variable
+- `AWS_S3_LOGS_SECRET_KEY`: To be set in the `AWS_S3_LOGS_SECRET_KEY` variable

--- a/modules/s3/outputs.tf
+++ b/modules/s3/outputs.tf
@@ -1,0 +1,23 @@
+output "s3_storage_bucket_name" {
+  value = aws_s3_bucket.edxapp.bucket
+}
+
+output "s3_storage_user_access_key" {
+  value = aws_iam_access_key.edxapp_s3_access_key.id
+}
+
+output "s3_storage_user_secret_key" {
+  value = aws_iam_access_key.edxapp_s3_access_key.secret
+}
+
+output "s3_tracking_logs_bucket_name" {
+  value = aws_s3_bucket.edxapp_tracking_logs.bucket
+}
+
+output "s3_tracking_logs_user_access_key" {
+  value = aws_iam_access_key.edxapp_tracking_logs_s3_access_key.id
+}
+
+output "s3_tracking_logs_user_secret_key" {
+  value = aws_iam_access_key.edxapp_tracking_logs_s3_access_key.secret
+}

--- a/modules/s3/storage.tf
+++ b/modules/s3/storage.tf
@@ -1,0 +1,45 @@
+data aws_iam_policy_document edxapp_s3_full_access {
+  version = "2012-10-17"
+  statement {
+    actions = [
+      "s3:*",
+    ]
+    effect = "Allow"
+
+    resources = [
+      aws_s3_bucket.edxapp.arn,
+      "${aws_s3_bucket.edxapp.arn}/*",
+    ]
+  }
+}
+
+resource aws_s3_bucket edxapp {
+  bucket = "${var.customer_name}-${var.environment}-edxapp-storage"
+  acl = "private"
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT", "GET"]
+    allowed_origins = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "edxapp_s3_full_access" {
+  name        = "${var.customer_name}-${var.environment}-edxapp-s3-full-access"
+  description = "Grants full access to s3 resources in the ${aws_s3_bucket.edxapp.id} bucket"
+
+  policy = data.aws_iam_policy_document.edxapp_s3_full_access.json
+}
+
+resource aws_iam_user edxapp_s3_user {
+  name = "${var.customer_name}-${var.environment}-edxapp-s3"
+}
+
+resource aws_iam_user_policy_attachment edxapp_s3_full_access {
+  policy_arn = aws_iam_policy.edxapp_s3_full_access.arn
+  user = aws_iam_user.edxapp_s3_user.name
+}
+
+resource aws_iam_access_key edxapp_s3_access_key {
+  user = aws_iam_user.edxapp_s3_user.name
+}

--- a/modules/s3/tracking_logs.tf
+++ b/modules/s3/tracking_logs.tf
@@ -1,0 +1,46 @@
+data aws_iam_policy_document edxapp_tracking_logs_s3_full_access {
+  version = "2012-10-17"
+  statement {
+    actions = [
+      "s3:*",
+    ]
+    effect = "Allow"
+
+    resources = [
+      aws_s3_bucket.edxapp_tracking_logs.arn,
+      "${aws_s3_bucket.edxapp_tracking_logs.arn}/*",
+    ]
+  }
+}
+
+
+resource aws_s3_bucket edxapp_tracking_logs {
+  bucket = "${var.customer_name}-${var.environment}-edxapp-tracking-logs"
+  acl = "private"
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT", "GET"]
+    allowed_origins = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "edxapp_tracking_logs_s3_full_access" {
+  name        = "${var.customer_name}-${var.environment}-edxapp-tracking-logs-s3-full-access"
+  description = "Grants full access to s3 resources in the ${aws_s3_bucket.edxapp_tracking_logs.id} bucket"
+
+  policy = data.aws_iam_policy_document.edxapp_tracking_logs_s3_full_access.json
+}
+
+resource aws_iam_user edxapp_tracking_logs_s3_user {
+  name = "${var.customer_name}-${var.environment}-edxapp-tracking-logs-s3"
+}
+
+resource aws_iam_user_policy_attachment edxapp_tracking_logs_s3_full_access {
+  policy_arn = aws_iam_policy.edxapp_tracking_logs_s3_full_access.arn
+  user = aws_iam_user.edxapp_tracking_logs_s3_user.name
+}
+
+resource aws_iam_access_key edxapp_tracking_logs_s3_access_key {
+  user = aws_iam_user.edxapp_tracking_logs_s3_user.name
+}

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -1,0 +1,2 @@
+variable "customer_name" {}
+variable "environment" {}

--- a/modules/services/director/README.md
+++ b/modules/services/director/README.md
@@ -1,0 +1,38 @@
+# The Director Instance
+
+For installation of OpenedX, we use this one as a secondary instance. OpenedX instance access should
+be done through the director, so this instance comes with everything configured (in terms of access)
+so the OpenedX instance can be reachable from the outside.
+
+The OpenedX instance shouldn't even be accessible through SSH from the public, only the director is
+able to access it (and we are the only ones with access to the director).
+
+## Assumptions
+
+- You've created/imported a "Key Pair" in AWS (it can be done through the console) and you have the
+public and private keys. They will be used for SSH access into the director instance. 
+
+*Note*: You should actually create two (one for the director and one for the edX instances)
+
+- Name the private key file as `director.pem` and place in the same folder as the terraform project
+that is using this module
+
+## Input
+
+You should get the following variables from AWS Console, with what's available
+for the region you are going to use:
+
+- `image_id`: AWS Image ID for this instance (e.g. ami-0edab4XXXXXXXXX)
+- `instance_type`: Instance type, we recommend to use the smallest one (e.g. `t2.micro`)
+- `director_key_pair_name`: Name you given to the AWS Key Pair to be used to ssh into the director
+
+## Output
+
+- `director_public_ip`: Informative, just so you know what instance to ssh into
+
+*Note*: To ssh into this instance you'll do something like:
+
+    ssh -i director.pem <user>@<director_public_ip>
+    
+To get the right command, you should go into the AWS console, select the director EC2 instance and 
+check how to "Connect" to it (for Ubuntu instances, the `<user>` is `ubuntu`)

--- a/modules/services/director/main.tf
+++ b/modules/services/director/main.tf
@@ -1,0 +1,50 @@
+resource aws_instance director {
+  ami = var.image_id
+  instance_type = var.instance_type
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  vpc_security_group_ids = [aws_security_group.director.id]
+
+  key_name = var.director_key_pair_name
+
+  tags = {
+    Name = "director"
+  }
+
+  connection {
+    type = "ssh"
+    host = self.public_ip
+    user = "ubuntu"
+    private_key = file("director.pem")
+  }
+
+  provisioner "remote-exec" {
+    inline = ["echo \"Hello, World from $(uname -smp)\""]
+  }
+}
+
+resource aws_security_group director {
+  name = "director"
+}
+
+resource aws_security_group_rule director-outbound {
+  type = "egress"
+  security_group_id = aws_security_group.director.id
+
+  from_port = 0
+  to_port = 0
+  protocol = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+resource aws_security_group_rule director-ssh-rule {
+  type = "ingress"
+  security_group_id = aws_security_group.director.id
+  from_port = 22
+  to_port = 22
+  protocol = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+}

--- a/modules/services/director/outputs.tf
+++ b/modules/services/director/outputs.tf
@@ -1,0 +1,3 @@
+output "director_instance_public_ip" {
+  value = aws_instance.director.public_ip
+}

--- a/modules/services/director/outputs.tf
+++ b/modules/services/director/outputs.tf
@@ -1,3 +1,7 @@
 output "director_instance_public_ip" {
   value = aws_instance.director.public_ip
 }
+
+output "director_security_group_id" {
+  value = aws_security_group.director.id
+}

--- a/modules/services/director/variables.tf
+++ b/modules/services/director/variables.tf
@@ -1,0 +1,4 @@
+variable "image_id" {}
+variable "instance_type" {}
+
+variable "director_key_pair_name" {}

--- a/modules/services/elasticsearch/README.md
+++ b/modules/services/elasticsearch/README.md
@@ -1,0 +1,16 @@
+# Elasticsearch
+
+AWS ElasticSearch Service, it's configured to allow full access but only from the specified AWS 
+security group (should be supplied as Input), which should normally be specified as the security
+group for the OpenedX instance.
+
+## Input
+
+- `customer_name`: the customer's name, this variable is used for resource naming
+- `environment`: `prod` for example, this variable is used for resource naming
+- `edxapp_security_group_id`: and AWS security group id, It should be the one configured for your
+OpenedX instance.
+
+## Output
+
+- `elasticsearch`: to be set in the `ELASTICSEARCH_HOST` variable (without the `https`) part

--- a/modules/services/elasticsearch/main.tf
+++ b/modules/services/elasticsearch/main.tf
@@ -1,0 +1,81 @@
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "default" {
+  vpc_id = data.aws_vpc.default.id
+}
+
+resource aws_elasticsearch_domain "openedx" {
+  domain_name = "${var.customer_name}-${var.environment}-elasticsearch"
+  elasticsearch_version = "1.5"
+
+  cluster_config {
+    instance_count = 2
+    instance_type = "t2.small.elasticsearch"
+    zone_awareness_enabled = true
+
+    dedicated_master_enabled = true
+    dedicated_master_type = "t2.small.elasticsearch"
+    dedicated_master_count = 3
+
+    zone_awareness_config {
+      availability_zone_count = 2
+    }
+  }
+
+  vpc_options {
+    subnet_ids = [
+      tolist(data.aws_subnet_ids.default.ids)[1],
+      tolist(data.aws_subnet_ids.default.ids)[2],
+    ]
+    security_group_ids = [aws_security_group.elasticsearch.id]
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_type = "gp2"
+    volume_size = 10
+  }
+
+  depends_on = [aws_iam_service_linked_role.elasticsearch]
+}
+
+resource aws_iam_service_linked_role "elasticsearch" {
+  aws_service_name = "es.amazonaws.com"
+  description      = "Allows Amazon ES to manage AWS resources for a domain on your behalf."
+}
+
+resource aws_security_group "elasticsearch" {
+  name = "${var.customer_name}-${var.environment}-edxapp-elasticsearch"
+}
+
+resource aws_security_group_rule "es-edxapp-inbound-rule" {
+  security_group_id = aws_security_group.elasticsearch.id
+  source_security_group_id = var.edxapp_security_group_id
+  type = "ingress"
+
+  from_port = 0
+  to_port = 0
+  protocol = "-1"
+}
+
+resource aws_security_group_rule "es-edxapp-inbound-own-rule" {
+  security_group_id = aws_security_group.elasticsearch.id
+  source_security_group_id = aws_security_group.elasticsearch.id
+  type = "ingress"
+
+  from_port = 0
+  to_port = 0
+  protocol = "-1"
+}
+
+resource aws_security_group_rule "es-edxapp-outbound-rule" {
+  security_group_id = aws_security_group.elasticsearch.id
+  type = "egress"
+
+  from_port = 0
+  to_port = 0
+  protocol = "all"
+  cidr_blocks = ["0.0.0.0/0"]
+}

--- a/modules/services/elasticsearch/outputs.tf
+++ b/modules/services/elasticsearch/outputs.tf
@@ -1,0 +1,3 @@
+output "elasticsearch" {
+  value = aws_elasticsearch_domain.openedx.endpoint
+}

--- a/modules/services/elasticsearch/variables.tf
+++ b/modules/services/elasticsearch/variables.tf
@@ -1,0 +1,3 @@
+variable "customer_name" {}
+variable "environment" {}
+variable "edxapp_security_group_id" {}

--- a/modules/services/mongodb/README.md
+++ b/modules/services/mongodb/README.md
@@ -1,0 +1,27 @@
+# MongoDB Cluster
+
+If the client needs a customized MongoDB Cluster to be maintained by OpenCraft
+
+> **IMPORTANT**: This isn't included in the normal maintenance plan we give to customers, so
+> they should agree to this by a higher cost. We should push the customer to use MongoDB Atlas
+> instead.
+
+## Input
+
+- `number_of_instances`: the number of instances belonging to this cluster
+- `image_id`: The image ID to be used by the instances
+- `instance_type`: The instance type to be used by the instances
+- `customer_name`
+- `environment`
+- `edxapp_security_group_id`: AWS Security Group ID to access this instance (should be the one
+specified for the edX instances)
+- `openedx_key_pair_name`: The Key Pair name to ssh into this instances (from the instances in
+the Security Group specified before)
+
+## Output
+
+- `mongodb_instances`: List of the Private IPs of the MongoDB instances (could be used for 
+the `EDXAPP_MONGO_HOSTS` variable)
+
+*Note*: You still need to configure a production-ready MongoDB service inside all of these instances,
+specifying a ReplicaSet, Auth and SSL configuration 

--- a/modules/services/mongodb/main.tf
+++ b/modules/services/mongodb/main.tf
@@ -1,0 +1,82 @@
+resource aws_instance "mongodb" {
+  count = var.number_of_instances
+  ami = var.image_id
+  instance_type = var.instance_type
+
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = 100
+  }
+
+  vpc_security_group_ids = [aws_security_group.security_group.id]
+  key_name = var.openedx_key_pair_name
+  user_data = file("scripts/install_mongodb.sh")
+
+  tags = {
+    Name = format("${var.customer_name}-${var.environment}-mongodb-%s", count.index > 0 ? join("-", [
+      "secondary",
+      tostring(count.index)]) : "primary")
+  }
+}
+
+resource aws_security_group "security_group" {
+  name = "${var.customer_name}-${var.environment}-edxapp-mongodb"
+}
+
+resource aws_security_group_rule "mongodb_edxapp_ingress_rule_1" {
+  security_group_id = aws_security_group.security_group.id
+  source_security_group_id = var.edxapp_security_group_id
+  type = "ingress"
+
+  from_port = 27017
+  to_port = 27017
+  protocol = "tcp"
+}
+
+resource aws_security_group_rule "mongodb_edxapp_ingress_rule_2" {
+  security_group_id = aws_security_group.security_group.id
+  source_security_group_id = var.edxapp_security_group_id
+  type = "ingress"
+
+  from_port = 27019
+  to_port = 27019
+  protocol = "tcp"
+}
+
+resource aws_security_group_rule "mongodb_edxapp_ingress_ssh_rule" {
+  security_group_id = aws_security_group.security_group.id
+  source_security_group_id = var.edxapp_security_group_id
+  type = "ingress"
+
+  from_port = 22
+  to_port = 22
+  protocol = "tcp"
+}
+
+resource aws_security_group_rule "mongodb_egress_rule" {
+  security_group_id = aws_security_group.security_group.id
+  type = "egress"
+
+  from_port = 0
+  to_port = 0
+  protocol = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+resource aws_security_group_rule "mongodb_replica_connection_inbound_rule" {
+  security_group_id = aws_security_group.security_group.id
+  source_security_group_id = aws_security_group.security_group.id
+  type = "ingress"
+  protocol = "-1"
+  from_port = 0
+  to_port = 0
+}
+
+resource aws_security_group_rule "mongodb_replica_connection_outbound_rule" {
+  security_group_id = aws_security_group.security_group.id
+  source_security_group_id = aws_security_group.security_group.id
+  type = "egress"
+  protocol = "-1"
+  from_port = 0
+  to_port = 0
+}

--- a/modules/services/mongodb/outputs.tf
+++ b/modules/services/mongodb/outputs.tf
@@ -1,0 +1,3 @@
+output "mongodb_instances" {
+  value = aws_instance.mongodb.*.private_ip
+}

--- a/modules/services/mongodb/variables.tf
+++ b/modules/services/mongodb/variables.tf
@@ -1,0 +1,9 @@
+variable "number_of_instances" {}
+variable "image_id" {}
+variable "instance_type" {}
+
+variable "customer_name" {}
+variable "environment" {}
+
+variable "openedx_key_pair_name" {}
+variable "edxapp_security_group_id" {}

--- a/modules/services/openedx/README.md
+++ b/modules/services/openedx/README.md
@@ -1,0 +1,77 @@
+# OpenedX Instance Setup
+
+This terraform module doesn't actually configure or even creates an OpenedX instance (AWS EC2
+instance), but it setups everything the AWS Instance needs for you to just plugin the instance
+on your own terraform script.
+
+So basically you can use this module, but you also need to create the instance, and add that 
+instance into the load balancers (that this module will create) on your own. It should look like this:
+
+    resource aws_instance edxapp {
+      ami = <Image ID>
+      instance_type = <Instance Type>
+      vpc_security_group_ids = [module.openedx.edxapp_security_group_id]
+    
+      root_block_device {
+        volume_size = 50        # setting only 50 GB for the edxapp disk space
+        volume_type = "gp2"
+      }
+    
+      key_name = <OpenedX Instance Key Pair Name>
+      user_data = file("scripts/setup_edx_instance.sh") # check the setup_edx_instance.sh.example
+                                                        # for what the instance needs installed
+    
+      tags = {
+        Name = "edxapp-<NUMBER>"  # keep adding resources and change the name
+      }
+    }
+    
+This is necessary because we still do the spawn of new instances manually, setting the <NUMBER>
+manually indicating the times we've deployed a new instance for this client.
+
+You also need to add the instance into the already configured load balancer. We are actually
+creating two load balancers, one that points to all subdomains, and another one for the root domain.
+We do this because of the SSL certificates we issue (one for the root domain and one for all 
+subdomains), we have to configure a Route53 record for each and then connect one load balancer to
+each of those records. Here the examples of how to add this instance into the load balancers:
+
+    resource aws_lb_target_group_attachment edxapp {
+      target_group_arn = module.openedx.edxapp_lb_target_group_arn
+      target_id = aws_instance.edxapp.id
+      port = 80
+    
+      lifecycle {
+        create_before_destroy = true
+      }
+    }
+    
+    resource aws_lb_target_group_attachment "edxapp_main_domain" {
+      target_group_arn = module.openedx.edxapp_main_domain_lb_target_group_arn
+      target_id = aws_instance.edxapp.id
+      port = 80
+    }
+
+You'll have to create the previous 3 resources every time you want to deploy a new OpenedX instance
+(for example every time you do a release update, bug fix, etc.).
+
+## Assumptions
+
+- A Route53 hosted zone has been created and its respective ACM Certificates have been issued.(check 
+the `route53` module)
+- 
+
+## Resources
+
+This module creates the following resources:
+
+- 2 **Application Load Balancer** (one for subdomains and one for the main domain) with its 
+respective security groups and listeneres
+- A **Security Group** for the OpenedX instance
+- All the necessary **Route 53 records** for the edX subdomains
+
+## Input
+
+- `customer_domain`: It should also match the Route53 configured domain
+- `customer_name`
+- `environment`
+- `director_security_group_id`: The director's security group ID (check the `director` module)

--- a/modules/services/openedx/lb.tf
+++ b/modules/services/openedx/lb.tf
@@ -1,0 +1,192 @@
+data aws_vpc "default" {
+  default = true
+}
+
+data aws_subnet_ids "default" {
+  vpc_id = data.aws_vpc.default.id
+}
+
+data aws_acm_certificate "customer_subdomains_certificate_arn" {
+  domain = "*.${var.customer_domain}"
+  statuses = ["ISSUED"]
+  most_recent = true
+}
+
+data aws_acm_certificate "customer_main_domain_certificate_arn" {
+  domain = var.customer_domain
+  statuses = ["ISSUED"]
+  most_recent = true
+}
+
+resource aws_lb "edxapp_main_domain" {
+  name = "${var.customer_name}-${var.environment}-edxapp-main-domain"
+  load_balancer_type = "application"
+  subnets = data.aws_subnet_ids.default.ids
+  security_groups = [aws_security_group.lb.id]
+}
+
+resource aws_lb_target_group "edxapp_main_domain" {
+  port = 80
+  protocol = "HTTP"
+  vpc_id = data.aws_vpc.default.id
+
+  health_check {
+    path = "/"
+    protocol = "HTTP"
+    matcher = "200"
+    interval = 15
+    timeout = 3
+    healthy_threshold = 2
+    unhealthy_threshold = 2
+  }
+}
+
+resource aws_lb_listener "main_domain_http" {
+  load_balancer_arn = aws_lb.edxapp_main_domain.arn
+  port = local.http_port
+  protocol = "HTTP"
+
+  default_action {
+    type = "forward"
+    target_group_arn = aws_lb_target_group.edxapp_main_domain.arn
+  }
+}
+
+resource aws_lb_listener "main_domain_https" {
+  load_balancer_arn = aws_lb.edxapp_main_domain.arn
+  port = local.https_port
+  protocol = "HTTPS"
+
+  ssl_policy = "ELBSecurityPolicy-2016-08"
+  certificate_arn = data.aws_acm_certificate.customer_main_domain_certificate_arn.arn
+
+
+  default_action {
+    type = "forward"
+    target_group_arn = aws_lb_target_group.edxapp_main_domain.arn
+  }
+}
+
+####################################################################################################
+resource aws_lb edxapp {
+  name = "${var.customer_name}-${var.environment}-edxapp"
+  load_balancer_type = "application"
+  subnets = data.aws_subnet_ids.default.ids
+  security_groups = [aws_security_group.lb.id]
+}
+
+resource aws_lb_target_group edxapp {
+  port = 80
+  protocol = "HTTP"
+  vpc_id = data.aws_vpc.default.id
+
+  health_check {
+    path = "/"
+    protocol = "HTTP"
+    matcher = "200"
+    interval = 15
+    timeout = 3
+    healthy_threshold = 2
+    unhealthy_threshold = 2
+  }
+}
+
+resource aws_lb_listener http {
+  load_balancer_arn = aws_lb.edxapp.arn
+  port = local.http_port
+  protocol = "HTTP"
+
+  default_action {
+    type = "forward"
+    target_group_arn = aws_lb_target_group.edxapp.arn
+  }
+}
+
+resource aws_lb_listener "https" {
+  load_balancer_arn = aws_lb.edxapp.arn
+  port = local.https_port
+  protocol = "HTTPS"
+
+  ssl_policy = "ELBSecurityPolicy-2016-08"
+  certificate_arn = data.aws_acm_certificate.customer_subdomains_certificate_arn.arn
+
+
+  default_action {
+    type = "forward"
+    target_group_arn = aws_lb_target_group.edxapp.arn
+  }
+}
+
+resource aws_security_group lb {
+  name = "${var.customer_name}-${var.environment}-edxapp-lb"
+}
+
+resource aws_security_group_rule lb-inbound-http {
+  type = "ingress"
+  security_group_id = aws_security_group.lb.id
+
+  from_port = local.http_port
+  to_port = local.http_port
+  protocol = local.tcp_protocol
+  cidr_blocks = local.all_ips
+}
+
+resource aws_security_group_rule lb-inbound-https {
+  type = "ingress"
+  security_group_id = aws_security_group.lb.id
+
+  from_port = local.https_port
+  to_port = local.https_port
+  protocol = local.tcp_protocol
+  cidr_blocks = local.all_ips
+}
+
+resource aws_security_group_rule lb-inbound-cms {
+  type = "ingress"
+  security_group_id = aws_security_group.lb.id
+
+  from_port = local.cms_port
+  to_port = local.cms_port
+  protocol = local.tcp_protocol
+  cidr_blocks = local.all_ips
+}
+
+resource aws_security_group_rule lb-inbound-tcp-prometheus {
+  type = "ingress"
+  security_group_id = aws_security_group.lb.id
+
+  from_port = local.prometheus_tcp_port
+  to_port = local.prometheus_tcp_port
+  protocol = local.tcp_protocol
+  cidr_blocks = local.all_ips
+}
+
+resource aws_security_group_rule lb-inbound-tcp-consul {
+  type = "ingress"
+  security_group_id = aws_security_group.lb.id
+
+  from_port = local.consul_tcp_from_port
+  to_port = local.consul_tcp_to_port
+  protocol = local.tcp_protocol
+  cidr_blocks = local.all_ips
+}
+
+resource aws_security_group_rule lb-inbound-udp-consul {
+  type = "ingress"
+  security_group_id = aws_security_group.lb.id
+
+  from_port = local.consul_udp_from_port
+  to_port = local.consul_udp_to_port
+  protocol = local.udp_protocol
+  cidr_blocks = local.all_ips
+}
+
+resource aws_security_group_rule lb-outbound {
+  type = "egress"
+  security_group_id = aws_security_group.lb.id
+
+  from_port = local.any_port
+  to_port = local.any_port
+  protocol = local.any_protocol
+  cidr_blocks = local.all_ips
+}

--- a/modules/services/openedx/locals.tf
+++ b/modules/services/openedx/locals.tf
@@ -1,0 +1,16 @@
+locals {
+  http_port = 80
+  https_port = 443
+  cms_port = 18010
+  prometheus_tcp_port = 19100
+  prometheus_udp_port = 19100
+  consul_tcp_from_port = 8301
+  consul_tcp_to_port = 8302
+  consul_udp_from_port = 8301
+  consul_udp_to_port = 8302
+  any_port = 0
+  any_protocol = "-1"
+  tcp_protocol = "tcp"
+  udp_protocol = "udp"
+  all_ips = ["0.0.0.0/0"]
+}

--- a/modules/services/openedx/main.tf
+++ b/modules/services/openedx/main.tf
@@ -1,0 +1,73 @@
+resource aws_security_group edxapp {
+  name = "${var.customer_name}-${var.environment}-edxapp"
+}
+
+resource aws_security_group_rule edxapp_inbound_rule {
+  security_group_id = aws_security_group.edxapp.id
+  type = "ingress"
+
+  from_port = 80
+  to_port = 80
+  protocol = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+resource aws_security_group_rule edxapp-inbound-tcp-prometheus {
+  type = "ingress"
+  security_group_id = aws_security_group.edxapp.id
+
+  from_port = local.prometheus_tcp_port
+  to_port = local.prometheus_tcp_port
+  protocol = local.tcp_protocol
+  cidr_blocks = local.all_ips
+}
+
+resource aws_security_group_rule edxapp-inbound-udp-prometheus {
+  type = "ingress"
+  security_group_id = aws_security_group.edxapp.id
+
+  from_port = local.prometheus_udp_port
+  to_port = local.prometheus_udp_port
+  protocol = local.udp_protocol
+  cidr_blocks = local.all_ips
+}
+
+resource aws_security_group_rule edxapp-inbound-tcp-consul {
+  type = "ingress"
+  security_group_id = aws_security_group.edxapp.id
+
+  from_port = local.consul_tcp_from_port
+  to_port = local.consul_tcp_to_port
+  protocol = local.tcp_protocol
+  cidr_blocks = local.all_ips
+}
+
+resource aws_security_group_rule edxapp-inbound-udp-consul {
+  type = "ingress"
+  security_group_id = aws_security_group.edxapp.id
+
+  from_port = local.consul_udp_from_port
+  to_port = local.consul_udp_to_port
+  protocol = local.udp_protocol
+  cidr_blocks = local.all_ips
+}
+
+resource aws_security_group_rule edxapp_director_ssh_rule {
+  security_group_id = aws_security_group.edxapp.id
+  source_security_group_id = var.director_security_group_id
+  type = "ingress"
+
+  from_port = 22
+  to_port = 22
+  protocol = "tcp"
+}
+
+resource aws_security_group_rule edxapp_outbound_rule {
+  security_group_id = aws_security_group.edxapp.id
+  type = "egress"
+
+  from_port = 0
+  to_port = 0
+  protocol = "all"
+  cidr_blocks = ["0.0.0.0/0"]
+}

--- a/modules/services/openedx/outputs.tf
+++ b/modules/services/openedx/outputs.tf
@@ -1,0 +1,11 @@
+output "edxapp_security_group_id" {
+  value = aws_security_group.edxapp.id
+}
+
+output "edxapp_lb_target_group_arn" {
+  value = aws_lb_target_group.edxapp.arn
+}
+
+output "edxapp_main_domain_lb_target_group_arn" {
+  value = aws_lb_target_group.edxapp_main_domain.arn
+}

--- a/modules/services/openedx/route53.tf
+++ b/modules/services/openedx/route53.tf
@@ -1,0 +1,39 @@
+data aws_route53_zone "route53_zone" {
+  name = "${var.customer_domain}."
+  private_zone = false
+}
+
+locals {
+  subdomains = [
+    "www",
+    "preview",
+    "studio",
+    "ecommerce",
+    "discovery",
+  ]
+}
+
+resource aws_route53_record "subdomain_lb_record" {
+  count = length(local.subdomains)
+  zone_id = data.aws_route53_zone.route53_zone.zone_id
+  name = "${local.subdomains[count.index]}.${data.aws_route53_zone.route53_zone.name}"
+  type = "A"
+
+  alias {
+    evaluate_target_health = false
+    name = aws_lb.edxapp.dns_name
+    zone_id = aws_lb.edxapp.zone_id
+  }
+}
+
+resource aws_route53_record "main_domain_lb_record" {
+  zone_id = data.aws_route53_zone.route53_zone.zone_id
+  name = data.aws_route53_zone.route53_zone.name
+  type = "A"
+
+  alias {
+    evaluate_target_health = false
+    name = aws_lb.edxapp_main_domain.dns_name
+    zone_id = aws_lb.edxapp_main_domain.zone_id
+  }
+}

--- a/modules/services/openedx/setup_edx_instance.sh.example
+++ b/modules/services/openedx/setup_edx_instance.sh.example
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+sudo apt-get update -y
+sudo apt-get install git python-pip python-dev build-essential libssl-dev libffi-dev
+sudo apt-get install libmysqlclient-dev mysql-client
+
+sudo add-apt-repository ppa:git-core/ppa -y
+sudo apt-get update -y
+sudo apt-get install git -y
+
+sudo pip install virtualenv virtualenvwrapper
+
+echo "system installation ready"

--- a/modules/services/openedx/variables.tf
+++ b/modules/services/openedx/variables.tf
@@ -1,0 +1,6 @@
+variable "customer_domain" {}
+
+variable "customer_name" {}
+variable "environment" {}
+
+variable "director_security_group_id" {}

--- a/modules/services/sql/README.md
+++ b/modules/services/sql/README.md
@@ -1,0 +1,19 @@
+# AWS RDS
+
+OpenedX needs MySQL, so we configure AWS RDS. We are configuring it be accessible only from an
+AWS Security Group
+
+## Input
+
+- `customer_name`
+- `environment`
+- `instance_class`: Class to be used by the RDS instance (like Instance Type)
+- `allocated_storage`: size of the instance allocated storage (in GB)
+- `database_root_username`: Root username, we normally set this to `opencraft`. To be set in the
+`EDXAPP_MYSQL_USER` variable
+- `database_root_password`: Root password. To be set in the `EDXAPP_MYSQL_PASSWORD` variable
+- `edxapp_security_group_id`: Security Group ID of the edX instance
+
+## Output
+
+- `mysql_host_name`: MySQL instance Endpoint. To be set in the `EDXAPP_MYSQL_HOST` variable

--- a/modules/services/sql/outputs.tf
+++ b/modules/services/sql/outputs.tf
@@ -1,0 +1,3 @@
+output "mysql_host_name" {
+  value = aws_db_instance.mysql_rds.endpoint
+}

--- a/modules/services/sql/rds.tf
+++ b/modules/services/sql/rds.tf
@@ -1,0 +1,66 @@
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "default" {
+  vpc_id = data.aws_vpc.default.id
+}
+
+resource aws_db_instance mysql_rds {
+  identifier = "${var.customer_name}-${var.environment}-openedx"
+  instance_class = var.instance_class
+  engine = "mysql"
+  engine_version = "5.6.48"
+
+  allocated_storage = var.allocated_storage
+  storage_type = "gp2"
+  backup_retention_period = 14
+
+  publicly_accessible = false
+  storage_encrypted = true
+  kms_key_id = aws_kms_key.rds_encryption.arn
+  auto_minor_version_upgrade = false
+  multi_az = false
+
+  deletion_protection = true
+
+  username = var.database_root_username
+  password = var.database_root_password
+
+  db_subnet_group_name = aws_db_subnet_group.primary.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+}
+
+resource aws_kms_key rds_encryption {
+  description = "KMS RDS Encryption"
+}
+
+resource aws_db_subnet_group primary {
+  name = "${var.customer_name}-${var.environment}-openedx"
+  subnet_ids = data.aws_subnet_ids.default.ids
+}
+
+resource aws_security_group rds {
+  name = "${var.customer_name}-${var.environment}-edxapp-rds"
+}
+
+resource aws_security_group_rule rds-outbound-rule {
+  security_group_id = aws_security_group.rds.id
+  type = "egress"
+  protocol = "all"
+  cidr_blocks = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+
+  from_port = 0
+  to_port = 0
+}
+
+resource aws_security_group_rule rds-inbound-rule {
+  type = "ingress"
+  security_group_id = aws_security_group.rds.id
+  source_security_group_id = var.edxapp_security_group_id
+
+  protocol = "tcp"
+  from_port = 3306
+  to_port = 3306
+}

--- a/modules/services/sql/variables.tf
+++ b/modules/services/sql/variables.tf
@@ -1,0 +1,10 @@
+variable "customer_name" {}
+variable "environment" {}
+
+variable "instance_class" {}
+variable "allocated_storage" {}
+
+variable "database_root_username" {}
+variable "database_root_password" {}
+
+variable "edxapp_security_group_id" {}


### PR DESCRIPTION
This merge request is about adding the configured (and currently used) terraform modules from UBC to this repo so they can be used and versioned into other projects that need AWS deployment

**Jira tickets**

- [SE-3475](https://tasks.opencraft.com/browse/SE-3575)

**Author's notes and concerns**
I copied them from UBC and checked them again, adding a readme into each of the modules. At least I'd like to merge this version as it is (we can improve the READMEs of course) and then improve on them if some resources need to be modified, as I need to also change UBC to point to these modules.

Still, if you think that some resources or anything needs more explaining, please let me know

**Reviewers**

- [ ] @pomegranited 
- [ ] @swalladge 
