### PR TITLE
Fix S3 bucket policy names to allow multiple environments without conflicts

### DIFF
--- a/modules/openedx/s3/edxapp-iam.tf
+++ b/modules/openedx/s3/edxapp-iam.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "edxapp_s3_full_access" {
 }
 
 resource "aws_iam_policy" "edxapp_s3_full_access" {
-  name        = "edxapp-s3-full-access"
+  name        = lower(join("-", [var.client_shortname, "edxapp", var.environment, "s3-full-access"]))
   description = "Grants full access to s3 resources in the ${aws_s3_bucket.edxapp.id} bucket"
 
   policy = data.aws_iam_policy_document.edxapp_s3_full_access.json

--- a/modules/openedx/s3/tracking-logs-iam.tf
+++ b/modules/openedx/s3/tracking-logs-iam.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "edxapp_tracking_logs_s3_full_access" {
 }
 
 resource "aws_iam_policy" "edxapp_tracking_logs_s3_full_access" {
-  name        = "edxapp-tracking-logs-s3-full-access"
+  name        = lower(join("-", [var.client_shortname, "edxapp", var.environment, "tracking-logs-s3-full-access"]))
   description = "Grants full access to s3 resources in the ${aws_s3_bucket.edxapp_tracking_logs.id} bucket"
 
   policy = data.aws_iam_policy_document.edxapp_tracking_logs_s3_full_access.json


### PR DESCRIPTION
When there are multiple environments to be set up, the existing terraform configuration uses the same name for the ACL policies on the edxapp and tracking logs bucket. This PR fixes that by adding a different pattern that includes the environment name.

**Testing instructions**:
* In an existing environment where the S3 bucket ACLs of the names (the ones before this PR) are already present, provisioning another environment like `staging` throws an error.
* Check out this PR branch.
* Verify that the terraform provisioning works and the ACLs are created with the new names as expected