### PR TITLE
[BB-3505] - Add memcached `engine version` parameter

### DIFF
--- a/modules/openedx/application/elasticache-clusters.tf
+++ b/modules/openedx/application/elasticache-clusters.tf
@@ -30,7 +30,7 @@ resource "aws_elasticache_cluster" "memcached" {
   engine               = "memcached"
   node_type            = var.memcached_node_type
   num_cache_nodes      = var.memcached_num_cache_nodes
-  parameter_group_name = var.memcached_parameter_group_name
+  engine_version       = var.memcached_engine_version
   port                 = var.memcached_port
 
   subnet_group_name  = aws_elasticache_subnet_group.elasticache_subnets.name

--- a/modules/openedx/application/elasticache-clusters.tf
+++ b/modules/openedx/application/elasticache-clusters.tf
@@ -30,6 +30,7 @@ resource "aws_elasticache_cluster" "memcached" {
   engine               = "memcached"
   node_type            = var.memcached_node_type
   num_cache_nodes      = var.memcached_num_cache_nodes
+  parameter_group_name = var.memcached_parameter_group_name
   engine_version       = var.memcached_engine_version
   port                 = var.memcached_port
 

--- a/modules/openedx/application/variables.tf
+++ b/modules/openedx/application/variables.tf
@@ -76,13 +76,12 @@ variable "memcached_num_cache_nodes" {
   type        = number
 }
 
-### Memcached Optional Settings ###########################
-
-variable "memcached_parameter_group_name" {
-  description = "The parameter group name for the ElastiCache Memcached deployment"
+variable "memcached_engine_version" {
+  description = "The engine version for the ElastiCache Memcached deployment"
   type        = string
-  default     = "default.memcached1.5"
 }
+
+### Memcached Optional Settings ###########################
 
 variable "memcached_port" {
   description = "The port to use for the ElastiCache Memcached deployment"

--- a/modules/openedx/application/variables.tf
+++ b/modules/openedx/application/variables.tf
@@ -76,9 +76,18 @@ variable "memcached_num_cache_nodes" {
   type        = number
 }
 
+### Memcached Optional Settings ###########################
+
 variable "memcached_engine_version" {
   description = "The engine version for the ElastiCache Memcached deployment"
   type        = string
+  default     = "1.5.16"
+}
+
+variable "memcached_parameter_group_name" {
+  description = "The parameter group name for the ElastiCache Memcached deployment"
+  type        = string
+  default     = "default.memcached1.5"
 }
 
 ### Memcached Optional Settings ###########################

--- a/modules/openedx/application/variables.tf
+++ b/modules/openedx/application/variables.tf
@@ -90,8 +90,6 @@ variable "memcached_parameter_group_name" {
   default     = "default.memcached1.5"
 }
 
-### Memcached Optional Settings ###########################
-
 variable "memcached_port" {
   description = "The port to use for the ElastiCache Memcached deployment"
   type        = number


### PR DESCRIPTION
Deploying the memcached cluster by specifying its `parameter group` results in the `CacheParameterGroupNotFound` error.