### PR TITLE
FAL-125: updates modules for Cloudera setup

### DIFF
--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -1,5 +1,9 @@
 resource aws_route53_zone "primary" {
   name = var.customer_domain
+
+  lifecycle {
+    prevent_destroy = var.prevent_route53_destruction
+  }
 }
 
 resource aws_acm_certificate "main_domain_certificate" {

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -2,14 +2,10 @@ resource aws_route53_zone "primary" {
   name = var.customer_domain
 }
 
-resource aws_acm_certificate "all_subdomains_certificate" {
+resource aws_acm_certificate "main_domain_certificate" {
   domain_name = "*.${var.customer_domain}"
   validation_method = "DNS"
-}
-
-resource aws_acm_certificate "main_domain_certificate" {
-  domain_name = var.customer_domain
-  validation_method = "DNS"
+  subject_alternative_names = [var.customer_domain]
 }
 
 resource aws_route53_record "main_domain_validation_records" {
@@ -34,34 +30,4 @@ resource aws_route53_record "main_domain_validation_records" {
 resource "aws_acm_certificate_validation" "main_domain_validation" {
   certificate_arn = aws_acm_certificate.main_domain_certificate.arn
   validation_record_fqdns = [for record in aws_route53_record.main_domain_validation_records : record.fqdn]
-}
-
-
-resource aws_acm_certificate "all_subdomains_certificate" {
-  domain_name = "*.${var.customer_domain}"
-  validation_method = "DNS"
-}
-
-resource aws_route53_record "all_subdomains_validation_records" {
-  for_each = {
-    for dvo in aws_acm_certificate.all_subdomains_certificate.domain_validation_options : dvo.domain_name => {
-      name = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type = dvo.resource_record_type
-    }
-  }
-
-  allow_overwrite = true
-  zone_id = aws_route53_zone.primary.zone_id
-  name = each.value.name
-  type = each.value.type
-  ttl = "60"
-  records = [
-    each.value.record
-  ]
-}
-
-resource "aws_acm_certificate_validation" "all_subdomains_validation" {
-  certificate_arn = aws_acm_certificate.all_subdomains_certificate.arn
-  validation_record_fqdns = [for record in aws_route53_record.all_subdomains_validation_records : record.fqdn]
 }

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -6,15 +6,19 @@ resource aws_route53_zone "primary" {
   }
 }
 
-# this was imported
 resource aws_acm_certificate "all_subdomains_certificate" {
+  domain_name = var.customer_domain
+  validation_method = "DNS"
+
   lifecycle {
     prevent_destroy = true
   }
 }
 
-# this was imported
 resource aws_acm_certificate "main_domain_certificate" {
+  domain_name = "*.${var.customer_domain}"
+  validation_method = "DNS"
+
   lifecycle {
     prevent_destroy = true
   }

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -1,25 +1,67 @@
 resource aws_route53_zone "primary" {
   name = var.customer_domain
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource aws_acm_certificate "all_subdomains_certificate" {
-  domain_name = var.customer_domain
+  domain_name = "*.${var.customer_domain}"
   validation_method = "DNS"
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource aws_acm_certificate "main_domain_certificate" {
+  domain_name = var.customer_domain
+  validation_method = "DNS"
+}
+
+resource aws_route53_record "main_domain_validation_records" {
+  for_each = {
+    for dvo in aws_acm_certificate.main_domain_certificate.domain_validation_options : dvo.domain_name => {
+      name = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  zone_id = aws_route53_zone.primary.zone_id
+  name = each.value.name
+  type = each.value.type
+  ttl = "60"
+  records = [
+    each.value.record
+  ]
+}
+
+resource "aws_acm_certificate_validation" "main_domain_validation" {
+  certificate_arn = aws_acm_certificate.main_domain_certificate.arn
+  validation_record_fqdns = [for record in aws_route53_record.main_domain_validation_records : record.fqdn]
+}
+
+
+resource aws_acm_certificate "all_subdomains_certificate" {
   domain_name = "*.${var.customer_domain}"
   validation_method = "DNS"
+}
 
-  lifecycle {
-    prevent_destroy = true
+resource aws_route53_record "all_subdomains_validation_records" {
+  for_each = {
+    for dvo in aws_acm_certificate.all_subdomains_certificate.domain_validation_options : dvo.domain_name => {
+      name = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type = dvo.resource_record_type
+    }
   }
+
+  allow_overwrite = true
+  zone_id = aws_route53_zone.primary.zone_id
+  name = each.value.name
+  type = each.value.type
+  ttl = "60"
+  records = [
+    each.value.record
+  ]
+}
+
+resource "aws_acm_certificate_validation" "all_subdomains_validation" {
+  certificate_arn = aws_acm_certificate.all_subdomains_certificate.arn
+  validation_record_fqdns = [for record in aws_route53_record.all_subdomains_validation_records : record.fqdn]
 }

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -3,8 +3,6 @@ resource aws_route53_zone "primary" {
 }
 
 resource aws_acm_certificate "main_domain_certificate" {
-  count = var.enable_acm_validation ? 1 : 0
-
   domain_name = "*.${var.customer_domain}"
   validation_method = "DNS"
   subject_alternative_names = [var.customer_domain]
@@ -12,7 +10,7 @@ resource aws_acm_certificate "main_domain_certificate" {
 
 resource aws_route53_record "main_domain_validation_records" {
   for_each = {
-    for dvo in (var.enable_acm_validation ? aws_acm_certificate.main_domain_certificate.domain_validation_options : []) : dvo.domain_name => {
+    for dvo in aws_acm_certificate.main_domain_certificate.domain_validation_options : dvo.domain_name => {
       name = dvo.resource_record_name
       record = dvo.resource_record_value
       type = dvo.resource_record_type

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -12,7 +12,7 @@ resource aws_acm_certificate "main_domain_certificate" {
 
 resource aws_route53_record "main_domain_validation_records" {
   for_each = {
-    for dvo in aws_acm_certificate.main_domain_certificate.domain_validation_options : dvo.domain_name => {
+    for dvo in (var.enable_acm_validation ? aws_acm_certificate.main_domain_certificate.domain_validation_options : []) : dvo.domain_name => {
       name = dvo.resource_record_name
       record = dvo.resource_record_value
       type = dvo.resource_record_type

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -2,7 +2,7 @@ resource aws_route53_zone "primary" {
   name = var.customer_domain
 
   lifecycle {
-    prevent_destroy = var.prevent_route53_destruction
+    prevent_destroy = true
   }
 }
 

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -3,6 +3,8 @@ resource aws_route53_zone "primary" {
 }
 
 resource aws_acm_certificate "main_domain_certificate" {
+  count = var.enable_acm_validation ? 1 : 0
+
   domain_name = "*.${var.customer_domain}"
   validation_method = "DNS"
   subject_alternative_names = [var.customer_domain]
@@ -28,6 +30,8 @@ resource aws_route53_record "main_domain_validation_records" {
 }
 
 resource "aws_acm_certificate_validation" "main_domain_validation" {
+  count = var.enable_acm_validation ? 1 : 0
+
   certificate_arn = aws_acm_certificate.main_domain_certificate.arn
   validation_record_fqdns = [for record in aws_route53_record.main_domain_validation_records : record.fqdn]
 }

--- a/modules/route53/variables.tf
+++ b/modules/route53/variables.tf
@@ -1,7 +1,3 @@
-variable "prevent_route53_destruction" {
-  default = true
-}
-
 variable "customer_domain" {
   description = "domain or subdomain provided by a customer that delegates to Route53"
 }

--- a/modules/route53/variables.tf
+++ b/modules/route53/variables.tf
@@ -1,3 +1,7 @@
+variable "prevent_route53_destruction" {
+  default = true
+}
+
 variable "customer_domain" {
   description = "domain or subdomain provided by a customer that delegates to Route53"
 }

--- a/modules/route53/variables.tf
+++ b/modules/route53/variables.tf
@@ -1,3 +1,7 @@
 variable "customer_domain" {
   description = "domain or subdomain provided by a customer that delegates to Route53"
 }
+
+variable "enable_acm_validation" {
+  default = true
+}

--- a/modules/services/cache/main.tf
+++ b/modules/services/cache/main.tf
@@ -1,0 +1,56 @@
+resource aws_elasticache_cluster redis {
+  cluster_id = var.redis_cluster_id
+  engine = "redis"
+  node_type = var.redis_node_type
+  num_cache_nodes = var.redis_num_cache_nodes
+  parameter_group_name = var.redis_parameter_group_name
+
+  security_group_ids = [aws_security_group.cache.id]
+  port = var.redis_port
+}
+
+resource aws_elasticache_cluster memcached {
+  cluster_id = var.memcached_cluster_id
+  engine = "memcached"
+  node_type = var.memcached_node_type
+  num_cache_nodes = var.memcached_num_cache_nodes
+  parameter_group_name = var.memcached_parameter_group_name
+
+  security_group_ids = [aws_security_group.cache.id]
+  port = var.memcached_port
+}
+
+resource aws_security_group cache {
+  name = "${var.customer_name}-${var.environment}-edxapp-cache"
+}
+
+resource aws_security_group_rule redis-outbound-rule {
+  security_group_id = aws_security_group.cache.id
+  type = "egress"
+  protocol = "all"
+  cidr_blocks = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+
+  from_port = 0
+  to_port = 0
+}
+
+resource aws_security_group_rule redis-inbound-rule {
+  type = "ingress"
+  security_group_id = aws_security_group.cache.id
+  source_security_group_id = var.edxapp_security_group_id
+
+  protocol = "all"
+  from_port = var.redis_port
+  to_port = var.redis_port
+}
+
+resource aws_security_group_rule memcached-inbound-rule {
+  type = "ingress"
+  security_group_id = aws_security_group.cache.id
+  source_security_group_id = var.edxapp_security_group_id
+
+  protocol = "all"
+  from_port = var.memcached_port
+  to_port = var.memcached_port
+}

--- a/modules/services/cache/main.tf
+++ b/modules/services/cache/main.tf
@@ -41,16 +41,6 @@ resource aws_security_group_rule redis-inbound-rule {
   source_security_group_id = var.edxapp_security_group_id
 
   protocol = "all"
-  from_port = var.redis_port
-  to_port = var.redis_port
-}
-
-resource aws_security_group_rule memcached-inbound-rule {
-  type = "ingress"
-  security_group_id = aws_security_group.cache.id
-  source_security_group_id = var.edxapp_security_group_id
-
-  protocol = "all"
-  from_port = var.memcached_port
-  to_port = var.memcached_port
+  from_port = 0
+  to_port = 0
 }

--- a/modules/services/cache/main.tf
+++ b/modules/services/cache/main.tf
@@ -1,8 +1,8 @@
 resource aws_elasticache_cluster redis {
-  cluster_id = var.redis_cluster_id
+  cluster_id = "edx-${var.customer_name}-${var.environment}-redis-cluster"
   engine = "redis"
   node_type = var.redis_node_type
-  num_cache_nodes = var.redis_num_cache_nodes
+  num_cache_nodes = 1   # redis doesn't support multiple nodes
   parameter_group_name = var.redis_parameter_group_name
 
   security_group_ids = [aws_security_group.cache.id]
@@ -10,7 +10,7 @@ resource aws_elasticache_cluster redis {
 }
 
 resource aws_elasticache_cluster memcached {
-  cluster_id = var.memcached_cluster_id
+  cluster_id = "edx-${var.customer_name}-${var.environment}-memcached-cluster"
   engine = "memcached"
   node_type = var.memcached_node_type
   num_cache_nodes = var.memcached_num_cache_nodes

--- a/modules/services/cache/outputs.tf
+++ b/modules/services/cache/outputs.tf
@@ -1,0 +1,3 @@
+output "redis_nodes" {
+  value = aws_elasticache_cluster.redis.cache_nodes
+}

--- a/modules/services/cache/outputs.tf
+++ b/modules/services/cache/outputs.tf
@@ -1,3 +1,7 @@
 output "redis_nodes" {
   value = aws_elasticache_cluster.redis.cache_nodes
 }
+
+output "memcached_nodes" {
+  value = aws_elasticache_cluster.memcached.cache_nodes
+}

--- a/modules/services/cache/variables.tf
+++ b/modules/services/cache/variables.tf
@@ -5,22 +5,13 @@ variable "edxapp_security_group_id" {}
 variable "redis_node_type" {
   default = "cache.m4.large"
 }
-variable "redis_num_cache_nodes" {
-  default = 1
-}
 variable "redis_parameter_group_name" {
   default = "default.redis6.x"
-}
-variable "redis_cluster_id" {
-  default = "edx-redis-cluster"
 }
 variable "redis_port" {
   default = 6379
 }
 
-variable "memcached_cluster_id" {
-  default = "edx-memcached-cluster"
-}
 variable "memcached_node_type" {
   default = "cache.m4.large"
 }

--- a/modules/services/cache/variables.tf
+++ b/modules/services/cache/variables.tf
@@ -1,0 +1,35 @@
+variable "customer_name" {}
+variable "environment" {}
+variable "edxapp_security_group_id" {}
+
+variable "redis_node_type" {
+  default = "cache.m4.large"
+}
+variable "redis_num_cache_nodes" {
+  default = 1
+}
+variable "redis_parameter_group_name" {
+  default = "default.redis6.x"
+}
+variable "redis_cluster_id" {
+  default = "edx-redis-cluster"
+}
+variable "redis_port" {
+  default = 6379
+}
+
+variable "memcached_cluster_id" {
+  default = "edx-memcached-cluster"
+}
+variable "memcached_node_type" {
+  default = "cache.m4.large"
+}
+variable "memcached_num_cache_nodes" {
+  default = 1
+}
+variable "memcached_parameter_group_name" {
+  default = "default.memcached1.5"
+}
+variable "memcached_port" {
+  default = 11211
+}

--- a/modules/services/director/main.tf
+++ b/modules/services/director/main.tf
@@ -27,7 +27,7 @@ resource aws_instance director {
 }
 
 resource aws_security_group director {
-  name = "director"
+  name = "edx-director"
 }
 
 resource aws_security_group_rule director-outbound {

--- a/modules/services/director/main.tf
+++ b/modules/services/director/main.tf
@@ -11,7 +11,7 @@ resource aws_instance director {
   key_name = var.director_key_pair_name
 
   tags = {
-    Name = "director"
+    Name = "edx-${var.environment}-director"
   }
 
   connection {
@@ -27,7 +27,7 @@ resource aws_instance director {
 }
 
 resource aws_security_group director {
-  name = "edx-director"
+  name = var.custom_security_group_name == "" ? "edx-${var.environment}-director" : var.custom_security_group_name
 }
 
 resource aws_security_group_rule director-outbound {

--- a/modules/services/director/variables.tf
+++ b/modules/services/director/variables.tf
@@ -2,3 +2,11 @@ variable "image_id" {}
 variable "instance_type" {}
 
 variable "director_key_pair_name" {}
+
+variable "environment" {
+  default = "prod"
+}
+
+variable "custom_security_group_name" {
+  default = ""
+}

--- a/modules/services/elasticsearch/main.tf
+++ b/modules/services/elasticsearch/main.tf
@@ -17,7 +17,7 @@ resource aws_elasticsearch_domain "openedx" {
 
     dedicated_master_enabled = true
     dedicated_master_type = var.elasticsearch_instance_type
-    dedicated_master_count = 3
+    dedicated_master_count = var.number_of_nodes
 
     zone_awareness_config {
       availability_zone_count = 2

--- a/modules/services/elasticsearch/main.tf
+++ b/modules/services/elasticsearch/main.tf
@@ -12,11 +12,11 @@ resource aws_elasticsearch_domain "openedx" {
 
   cluster_config {
     instance_count = 2
-    instance_type = "t2.small.elasticsearch"
+    instance_type = var.elasticsearch_instance_type
     zone_awareness_enabled = true
 
     dedicated_master_enabled = true
-    dedicated_master_type = "t2.small.elasticsearch"
+    dedicated_master_type = var.elasticsearch_instance_type
     dedicated_master_count = 3
 
     zone_awareness_config {

--- a/modules/services/elasticsearch/variables.tf
+++ b/modules/services/elasticsearch/variables.tf
@@ -4,3 +4,6 @@ variable "edxapp_security_group_id" {}
 variable "elasticsearch_instance_type" {
   default = "t2.small.elasticsearch"
 }
+variable "number_of_nodes" {
+  default = 3
+}

--- a/modules/services/elasticsearch/variables.tf
+++ b/modules/services/elasticsearch/variables.tf
@@ -1,3 +1,6 @@
 variable "customer_name" {}
 variable "environment" {}
 variable "edxapp_security_group_id" {}
+variable "elasticsearch_instance_type" {
+  default = "t2.small.elasticsearch"
+}

--- a/modules/services/openedx/lb.tf
+++ b/modules/services/openedx/lb.tf
@@ -12,56 +12,6 @@ data aws_acm_certificate "customer_subdomains_certificate_arn" {
   most_recent = true
 }
 
-resource aws_lb "edxapp_main_domain" {
-  name = "${var.customer_name}-${var.environment}-edxapp-main-domain"
-  load_balancer_type = "application"
-  subnets = data.aws_subnet_ids.default.ids
-  security_groups = [aws_security_group.lb.id]
-}
-
-resource aws_lb_target_group "edxapp_main_domain" {
-  port = 80
-  protocol = "HTTP"
-  vpc_id = data.aws_vpc.default.id
-
-  health_check {
-    path = "/"
-    protocol = "HTTP"
-    matcher = "200"
-    interval = 15
-    timeout = 3
-    healthy_threshold = 2
-    unhealthy_threshold = 2
-  }
-}
-
-resource aws_lb_listener "main_domain_http" {
-  load_balancer_arn = aws_lb.edxapp_main_domain.arn
-  port = local.http_port
-  protocol = "HTTP"
-
-  default_action {
-    type = "forward"
-    target_group_arn = aws_lb_target_group.edxapp_main_domain.arn
-  }
-}
-
-resource aws_lb_listener "main_domain_https" {
-  load_balancer_arn = aws_lb.edxapp_main_domain.arn
-  port = local.https_port
-  protocol = "HTTPS"
-
-  ssl_policy = "ELBSecurityPolicy-2016-08"
-  certificate_arn = data.aws_acm_certificate.customer_subdomains_certificate_arn.arn
-
-
-  default_action {
-    type = "forward"
-    target_group_arn = aws_lb_target_group.edxapp_main_domain.arn
-  }
-}
-
-####################################################################################################
 resource aws_lb edxapp {
   name = "${var.customer_name}-${var.environment}-edxapp"
   load_balancer_type = "application"

--- a/modules/services/openedx/lb.tf
+++ b/modules/services/openedx/lb.tf
@@ -12,12 +12,6 @@ data aws_acm_certificate "customer_subdomains_certificate_arn" {
   most_recent = true
 }
 
-data aws_acm_certificate "customer_main_domain_certificate_arn" {
-  domain = var.customer_domain
-  statuses = ["ISSUED"]
-  most_recent = true
-}
-
 resource aws_lb "edxapp_main_domain" {
   name = "${var.customer_name}-${var.environment}-edxapp-main-domain"
   load_balancer_type = "application"
@@ -58,7 +52,7 @@ resource aws_lb_listener "main_domain_https" {
   protocol = "HTTPS"
 
   ssl_policy = "ELBSecurityPolicy-2016-08"
-  certificate_arn = data.aws_acm_certificate.customer_main_domain_certificate_arn.arn
+  certificate_arn = data.aws_acm_certificate.customer_subdomains_certificate_arn.arn
 
 
   default_action {

--- a/modules/services/openedx/outputs.tf
+++ b/modules/services/openedx/outputs.tf
@@ -5,7 +5,3 @@ output "edxapp_security_group_id" {
 output "edxapp_lb_target_group_arn" {
   value = aws_lb_target_group.edxapp.arn
 }
-
-output "edxapp_main_domain_lb_target_group_arn" {
-  value = aws_lb_target_group.edxapp_main_domain.arn
-}

--- a/modules/services/openedx/route53.tf
+++ b/modules/services/openedx/route53.tf
@@ -3,20 +3,10 @@ data aws_route53_zone "route53_zone" {
   private_zone = false
 }
 
-locals {
-  subdomains = [
-    "www",
-    "preview",
-    "studio",
-    "ecommerce",
-    "discovery",
-  ]
-}
-
 resource aws_route53_record "subdomain_lb_record" {
-  count = length(local.subdomains)
+  count = length(var.route53_subdomains)
   zone_id = data.aws_route53_zone.route53_zone.zone_id
-  name = "${local.subdomains[count.index]}.${data.aws_route53_zone.route53_zone.name}"
+  name = "${var.route53_subdomains[count.index]}.${data.aws_route53_zone.route53_zone.name}"
   type = "A"
 
   alias {

--- a/modules/services/openedx/route53.tf
+++ b/modules/services/openedx/route53.tf
@@ -33,7 +33,7 @@ resource aws_route53_record "main_domain_lb_record" {
 
   alias {
     evaluate_target_health = false
-    name = aws_lb.edxapp_main_domain.dns_name
-    zone_id = aws_lb.edxapp_main_domain.zone_id
+    name = aws_lb.edxapp.dns_name
+    zone_id = aws_lb.edxapp.zone_id
   }
 }

--- a/modules/services/openedx/variables.tf
+++ b/modules/services/openedx/variables.tf
@@ -4,3 +4,13 @@ variable "customer_name" {}
 variable "environment" {}
 
 variable "director_security_group_id" {}
+
+variable "route53_subdomains" {
+  default = [
+    "www",
+    "preview",
+    "studio",
+    "ecommerce",
+    "discovery",
+  ]
+}

--- a/modules/services/sql/outputs.tf
+++ b/modules/services/sql/outputs.tf
@@ -1,3 +1,3 @@
 output "mysql_host_name" {
-  value = aws_db_instance.mysql_rds.endpoint
+  value = aws_db_instance.mysql_rds.*.endpoint
 }

--- a/modules/services/sql/outputs.tf
+++ b/modules/services/sql/outputs.tf
@@ -1,3 +1,3 @@
 output "mysql_host_name" {
-  value = aws_db_instance.mysql_rds.*.endpoint
+  value = aws_db_instance.mysql_rds.endpoint
 }

--- a/modules/services/sql/rds.tf
+++ b/modules/services/sql/rds.tf
@@ -35,7 +35,7 @@ resource aws_db_instance mysql_rds {
 ## This is exactly the same as the master
 resource aws_db_instance mysql_rds_replicas {
   count = var.number_of_replicas
-  identifier = "${var.customer_name}-${var.environment}-openedx"
+  identifier = "${var.customer_name}-${var.environment}-openedx-replica-${count.index}"
   instance_class = var.instance_class
   engine = "mysql"
   engine_version = var.engine_version

--- a/modules/services/sql/rds.tf
+++ b/modules/services/sql/rds.tf
@@ -7,7 +7,6 @@ data "aws_subnet_ids" "default" {
 }
 
 resource aws_db_instance mysql_rds {
-  count = var.with_read_replica ? 2 : 1
   identifier = "${var.customer_name}-${var.environment}-openedx"
   instance_class = var.instance_class
   engine = "mysql"
@@ -22,7 +21,35 @@ resource aws_db_instance mysql_rds {
   kms_key_id = aws_kms_key.rds_encryption.arn
   auto_minor_version_upgrade = false
   multi_az = true
-  replicate_source_db = count.index != 0 ? aws_db_instance.mysql_rds.0.arn : null
+
+  deletion_protection = true
+
+  username = var.database_root_username
+  password = var.database_root_password
+
+  db_subnet_group_name = aws_db_subnet_group.primary.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+}
+
+
+## This is exactly the same as the master
+resource aws_db_instance mysql_rds_replicas {
+  count = var.number_of_replicas
+  identifier = "${var.customer_name}-${var.environment}-openedx"
+  instance_class = var.instance_class
+  engine = "mysql"
+  engine_version = var.engine_version
+
+  allocated_storage = var.allocated_storage
+  storage_type = "gp2"
+  backup_retention_period = 14
+
+  publicly_accessible = false
+  storage_encrypted = true
+  kms_key_id = aws_kms_key.rds_encryption.arn
+  auto_minor_version_upgrade = false
+  multi_az = true
+  replicate_source_db = aws_db_instance.mysql_rds.arn
 
   deletion_protection = true
 

--- a/modules/services/sql/rds.tf
+++ b/modules/services/sql/rds.tf
@@ -40,13 +40,12 @@ resource aws_db_instance mysql_rds_replicas {
   engine_version = var.engine_version
 
   storage_type = "gp2"
-  backup_retention_period = 14
 
   publicly_accessible = false
   storage_encrypted = true
   kms_key_id = aws_kms_key.rds_encryption.arn
   auto_minor_version_upgrade = false
-  multi_az = var.enable_multi_az
+  multi_az = var.enable_replica_multi_az
   replicate_source_db = aws_db_instance.mysql_rds.identifier
 
   skip_final_snapshot = true

--- a/modules/services/sql/rds.tf
+++ b/modules/services/sql/rds.tf
@@ -50,7 +50,7 @@ resource aws_db_instance mysql_rds_replicas {
   replicate_source_db = aws_db_instance.mysql_rds.arn
 
   deletion_protection = true
-  skip_final_snapshot = false
+  skip_final_snapshot = true
 
   db_subnet_group_name = aws_db_subnet_group.primary.name
   vpc_security_group_ids = [aws_security_group.rds.id]

--- a/modules/services/sql/rds.tf
+++ b/modules/services/sql/rds.tf
@@ -47,9 +47,8 @@ resource aws_db_instance mysql_rds_replicas {
   kms_key_id = aws_kms_key.rds_encryption.arn
   auto_minor_version_upgrade = false
   multi_az = true
-  replicate_source_db = aws_db_instance.mysql_rds.arn
+  replicate_source_db = aws_db_instance.mysql_rds.identifier
 
-  deletion_protection = true
   skip_final_snapshot = true
 
   db_subnet_group_name = aws_db_subnet_group.primary.name

--- a/modules/services/sql/rds.tf
+++ b/modules/services/sql/rds.tf
@@ -20,7 +20,7 @@ resource aws_db_instance mysql_rds {
   storage_encrypted = true
   kms_key_id = aws_kms_key.rds_encryption.arn
   auto_minor_version_upgrade = false
-  multi_az = true
+  multi_az = var.enable_multi_az
 
   deletion_protection = true
 
@@ -46,7 +46,7 @@ resource aws_db_instance mysql_rds_replicas {
   storage_encrypted = true
   kms_key_id = aws_kms_key.rds_encryption.arn
   auto_minor_version_upgrade = false
-  multi_az = true
+  multi_az = var.enable_multi_az
   replicate_source_db = aws_db_instance.mysql_rds.identifier
 
   skip_final_snapshot = true

--- a/modules/services/sql/rds.tf
+++ b/modules/services/sql/rds.tf
@@ -37,10 +37,8 @@ resource aws_db_instance mysql_rds_replicas {
   count = var.number_of_replicas
   identifier = "${var.customer_name}-${var.environment}-openedx-replica-${count.index}"
   instance_class = var.instance_class
-  engine = "mysql"
   engine_version = var.engine_version
 
-  allocated_storage = var.allocated_storage
   storage_type = "gp2"
   backup_retention_period = 14
 
@@ -52,9 +50,7 @@ resource aws_db_instance mysql_rds_replicas {
   replicate_source_db = aws_db_instance.mysql_rds.arn
 
   deletion_protection = true
-
-  username = var.database_root_username
-  password = var.database_root_password
+  skip_final_snapshot = false
 
   db_subnet_group_name = aws_db_subnet_group.primary.name
   vpc_security_group_ids = [aws_security_group.rds.id]

--- a/modules/services/sql/rds.tf
+++ b/modules/services/sql/rds.tf
@@ -7,10 +7,11 @@ data "aws_subnet_ids" "default" {
 }
 
 resource aws_db_instance mysql_rds {
+  count = var.with_read_replica ? 2 : 1
   identifier = "${var.customer_name}-${var.environment}-openedx"
   instance_class = var.instance_class
   engine = "mysql"
-  engine_version = "5.6.48"
+  engine_version = var.engine_version
 
   allocated_storage = var.allocated_storage
   storage_type = "gp2"
@@ -20,7 +21,8 @@ resource aws_db_instance mysql_rds {
   storage_encrypted = true
   kms_key_id = aws_kms_key.rds_encryption.arn
   auto_minor_version_upgrade = false
-  multi_az = false
+  multi_az = true
+  replicate_source_db = count.index != 0 ? aws_db_instance.mysql_rds.0.arn : null
 
   deletion_protection = true
 

--- a/modules/services/sql/variables.tf
+++ b/modules/services/sql/variables.tf
@@ -2,9 +2,16 @@ variable "customer_name" {}
 variable "environment" {}
 
 variable "instance_class" {}
+variable "engine_version" {
+  default = "5.6.48"
+}
 variable "allocated_storage" {}
 
 variable "database_root_username" {}
 variable "database_root_password" {}
 
 variable "edxapp_security_group_id" {}
+
+variable "with_read_replica" {
+  default = false
+}

--- a/modules/services/sql/variables.tf
+++ b/modules/services/sql/variables.tf
@@ -12,6 +12,6 @@ variable "database_root_password" {}
 
 variable "edxapp_security_group_id" {}
 
-variable "with_read_replica" {
-  default = false
+variable "number_of_replicas" {
+  default = 0
 }

--- a/modules/services/sql/variables.tf
+++ b/modules/services/sql/variables.tf
@@ -15,3 +15,7 @@ variable "edxapp_security_group_id" {}
 variable "number_of_replicas" {
   default = 0
 }
+
+variable "enable_multi_az" {
+  default = false
+}

--- a/modules/services/sql/variables.tf
+++ b/modules/services/sql/variables.tf
@@ -19,3 +19,7 @@ variable "number_of_replicas" {
 variable "enable_multi_az" {
   default = false
 }
+
+variable "enable_replica_multi_az" {
+  default = false
+}


### PR DESCRIPTION
This merge request is about updating the necessary modules for making Cloudera work

### Changes

- Adds the edx prefix to the director SG
- aws_acm_certificate resources are no longer imported, but configured entirely with Route53 validation
- Only one aws_acm_certificate for the main domain and all subdomains
- RDS setup to be multi_az with configurable MySQL version and ability to create replicas
- New Cache module with redis and memcached configuration
- Removes unnecessary double ACM and Load Balancers
- Adds the ElasticSearch open policy


### Jira tickets
- [FAL-125](https://tasks.opencraft.com/browse/FAL-125)

### Reviewers

- [x] @pomegranited
