### PR TITLE
FAL-162 Adds optional customer_domain_extra_records

### DIFF
--- a/modules/route53/README.md
+++ b/modules/route53/README.md
@@ -8,9 +8,11 @@ Very simple placeholder, to initialize Route53 to be used by other modules (emai
 - The user will have to configure its DNS provider to point NS records to the provided nameservers
 
 ## Input
-It only needs one variable:
 
-- `customer_domain`: domain or subdomain provided by a customer that delegates to Route53
+- `customer_domain`: (required) domain or subdomain provided by a customer that delegates to Route53
+- `customer_domain_extra_records`: (optional) map objects specifying additional DNS records to add to the customer domain zone.
+   Map key becomes the record `name`, and the record `value`, `type`, `ttl` are pulled from the object.
+- `enable_acm_validation`: (optional, default true) Set to false if the DNS records won't validate (yet).
 
 ## Output
 

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -31,6 +31,19 @@ resource aws_route53_record "main_domain_validation_records" {
   ]
 }
 
+resource aws_route53_record "main_domain_extra_records" {
+  for_each = var.customer_domain_extra_records
+
+  allow_overwrite = true
+  zone_id = aws_route53_zone.primary.zone_id
+  name = each.key
+  type = each.value.type
+  ttl = each.value.ttl
+  records = [
+    each.value.value
+  ]
+}
+
 resource "aws_acm_certificate_validation" "main_domain_validation" {
   count = var.enable_acm_validation ? 1 : 0
 

--- a/modules/route53/variables.tf
+++ b/modules/route53/variables.tf
@@ -2,6 +2,17 @@ variable "customer_domain" {
   description = "domain or subdomain provided by a customer that delegates to Route53"
 }
 
+variable "customer_domain_extra_records" {
+  description = "Map of subdomain records to append to the customer_domain zone"
+  type = map(object({
+    type = string
+    value = string
+    ttl = number
+  }))
+  default = {}
+}
+
 variable "enable_acm_validation" {
+  description = "Wait for validation of AWS cetificate created for customer_domain"
   default = true
 }


### PR DESCRIPTION
Adds an optional variable, `customer_domain_extra_records`, which allows us to add arbitrary extra records to the `customer_domain` Route53 zone.

**Testing instructions**

1. Confirm that the new variable is optional by setting up a basic route53 zone:

   ```terraform
   module "client_route53" {
    source = "git@github.com:open-craft/terraform-scripts.git//modules/route53?ref=jill/add-customer_domain_extra_records"
    customer_domain = local.customer_domain
   }
   ```
   Run `terraform plan` to confirm that the zone setup will run without any extra records specified. 
1. Specify extra domains in your `variables.tf` file, e.g. 

   ```terraform
   module "client_route53" {
     source = "git@github.com:open-craft/terraform-scripts.git//modules/route53?ref=jill/add-customer_domain_extra_records"
     customer_domain = local.customer_domain
     customer_domain_extra_records = {
       "someip" = {
         type = "A"
         value = "149.212.178.291"
         ttl = 3600
       },
       "cloudfront" = {
         type = "CNAME"
         value = "dn2v6j9q.cloudfront.net."
         ttl = 60
       },
     }
   } 
   ```

   Run `terraform plan` to see how the extra records would be added.

**Reviewer**

- [ ] @eLRuLL 