### PR TITLE
FAL-163 Allow openedx to be set up prior to certificate validation

### DIFF
--- a/modules/openedx/application/data.tf
+++ b/modules/openedx/application/data.tf
@@ -4,7 +4,7 @@ data "aws_subnet_ids" "subnets" {
 
 data "aws_acm_certificate" "certificate" {
   domain      = var.aws_acm_certificate_domain
-  statuses    = ["ISSUED"]
+  statuses    = ["ISSUED", "PENDING_VALIDATION"]
   most_recent = true
 }
 

--- a/modules/services/elasticsearch/main.tf
+++ b/modules/services/elasticsearch/main.tf
@@ -61,6 +61,8 @@ POLICY
 }
 
 resource aws_iam_service_linked_role "elasticsearch" {
+  # there can only be one
+  count = var.create_iam_service_linked_role ? 1 : 0
   aws_service_name = "es.amazonaws.com"
   description      = "Allows Amazon ES to manage AWS resources for a domain on your behalf."
 }

--- a/modules/services/elasticsearch/variables.tf
+++ b/modules/services/elasticsearch/variables.tf
@@ -7,3 +7,6 @@ variable "elasticsearch_instance_type" {
 variable "number_of_nodes" {
   default = 3
 }
+variable "create_iam_service_linked_role" {
+  default = true
+}

--- a/modules/services/openedx/variables.tf
+++ b/modules/services/openedx/variables.tf
@@ -14,3 +14,8 @@ variable "route53_subdomains" {
     "discovery",
   ]
 }
+
+variable enable_https {
+  description = "Cannot enable HTTPS until there is a valid customer_domain certificate"
+  default = true
+}


### PR DESCRIPTION
Fixes issues encountered when adding a secondary `stage` deployment, prior to DNS handover.

* When the DNS handover/SSL validation is pending, we can't create an https ELB listener, so we just create the http listener.
  But once SSL certificate is valid/issued, we can create an https listener.
* When there's an https listener, the http listener should redirect there.
* Can only create one ES service-linked role.

**Testing instructions**

Code review + testing the deployed instance from https://gitlab.com/opencraft/client/cloudera/cloudera-secure-configuration/-/merge_requests/11 should be sufficient here.

**Reviewer**

- [ ] @eLRuLL 
