### PR TITLE
RDS - Extra security groups and publicly accessibility

### DIFF
--- a/modules/services/sql/rds.tf
+++ b/modules/services/sql/rds.tf
@@ -28,7 +28,7 @@ resource aws_db_instance mysql_rds {
   password = var.database_root_password
 
   db_subnet_group_name = aws_db_subnet_group.primary.name
-  vpc_security_group_ids = concat([aws_security_group.rds.id], var.extra_security_group_ids)
+  vpc_security_group_ids = [aws_security_group.rds.id]
 
   max_allocated_storage = var.max_allocated_storage
 }
@@ -43,12 +43,13 @@ resource aws_db_instance mysql_rds_replicas {
 
   storage_type = "gp2"
 
-  publicly_accessible = false
+  publicly_accessible = var.replica_publicly_accessible
   storage_encrypted = true
   kms_key_id = aws_kms_key.rds_encryption.arn
   auto_minor_version_upgrade = false
   multi_az = var.enable_replica_multi_az
   replicate_source_db = aws_db_instance.mysql_rds.identifier
+  vpc_security_group_ids = [var.replica_extra_security_group_ids]
 
   skip_final_snapshot = true
 

--- a/modules/services/sql/rds.tf
+++ b/modules/services/sql/rds.tf
@@ -49,7 +49,7 @@ resource aws_db_instance mysql_rds_replicas {
   auto_minor_version_upgrade = false
   multi_az = var.enable_replica_multi_az
   replicate_source_db = aws_db_instance.mysql_rds.identifier
-  vpc_security_group_ids = [var.replica_extra_security_group_ids]
+  vpc_security_group_ids = var.replica_extra_security_group_ids
 
   skip_final_snapshot = true
 

--- a/modules/services/sql/rds.tf
+++ b/modules/services/sql/rds.tf
@@ -28,7 +28,7 @@ resource aws_db_instance mysql_rds {
   password = var.database_root_password
 
   db_subnet_group_name = aws_db_subnet_group.primary.name
-  vpc_security_group_ids = [aws_security_group.rds.id]
+  vpc_security_group_ids = concat([aws_security_group.rds.id], var.extra_security_group_ids)
 
   max_allocated_storage = var.max_allocated_storage
 }

--- a/modules/services/sql/variables.tf
+++ b/modules/services/sql/variables.tf
@@ -26,3 +26,7 @@ variable "enable_multi_az" {
 variable "enable_replica_multi_az" {
   default = false
 }
+
+variable "extra_security_group_ids" {
+  default = []
+}

--- a/modules/services/sql/variables.tf
+++ b/modules/services/sql/variables.tf
@@ -27,6 +27,10 @@ variable "enable_replica_multi_az" {
   default = false
 }
 
-variable "extra_security_group_ids" {
+variable "replica_extra_security_group_ids" {
   default = []
+}
+
+variable "replica_publicly_accessible" {
+  default = false
 }


### PR DESCRIPTION
This pull request is about adding new `replica_extra_security_group_ids` and `replica_publicly_accessible` variables.

- `replica_extra_security_group_ids`: Allow to set extra security groups to the replica (default: `[]`)
- `replica_publicly_accessible`: Set the replica as publicly accessible (default: `false`)

**Jira tickets*

- [FAL-301](https://tasks.opencraft.com/browse/FAL-301)

**Reviewers**

- ?