### PR TITLE
[FAL-252] Add a variable to set the  ssl security policy used by the load balancer

### DIFF
--- a/modules/services/openedx/README.md
+++ b/modules/services/openedx/README.md
@@ -78,3 +78,4 @@ respective security groups and listeneres
 - `route53_subdomains`: Subdomains to add as route53 records pointing to the Load Balancer
 - `lb_idle_timeout`: Load Balancer idle timeout
 - `enable_https`: If your ACM is not issued just yet or you don't need https, set this to `false`  
+- `lb_ssl_security_policy`: The predefined AWS ssl policy to be used by the load balancer. Defaults to "ELBSecurityPolicy-2016-08"

--- a/modules/services/openedx/lb.tf
+++ b/modules/services/openedx/lb.tf
@@ -43,7 +43,7 @@ resource aws_lb_listener "https" {
   port = local.https_port
   protocol = "HTTPS"
 
-  ssl_policy = "ELBSecurityPolicy-2016-08"
+  ssl_policy = var.lb_ssl_security_policy
   certificate_arn = data.aws_acm_certificate.customer_subdomains_certificate_arn.arn
 
 

--- a/modules/services/openedx/variables.tf
+++ b/modules/services/openedx/variables.tf
@@ -23,3 +23,8 @@ variable enable_https {
   description = "Cannot enable HTTPS until there is a valid customer_domain certificate"
   default = true
 }
+
+variable "lb_ssl_security_policy" {
+  description = "The AWS ssl security policy to be used by load balancer"
+  default = "ELBSecurityPolicy-2016-08"
+}


### PR DESCRIPTION
Add the ability to explicitly set the ssl security policy (pre-defined by AWS) to be used by the load balancer produced by the 'services/opendex' module.

**JIRA tickets**:  https://tasks.opencraft.com/browse/FAL-252

**Dependencies**:  This is required by https://gitlab.com/opencraft/client/cloudera/cloudera-secure-configuration/-/merge_requests/13

**Testing instructions**: 

The MR https://gitlab.com/opencraft/client/cloudera/cloudera-secure-configuration/-/merge_requests/13 has been set up to test this functionality pre-merge. So there is a mutual test here. Hope thats okay.

**Reviewers**:
- [x] @eLRuLL 