### PR TITLE
[FAL-1775]: adds multiple instance support to analytics

### DIFF
--- a/modules/services/analytics/README.md
+++ b/modules/services/analytics/README.md
@@ -27,6 +27,10 @@ https://github.com/open-craft/openedx-deployment/blob/master/docs/analytics/AWS_
 - `edxapp_s3_grade_bucket_id`: bucket ID of the `grades` bucket used for the edX instance
 - `edxapp_s3_grade_bucket_arn`: same as before, but the ARN
 - `edxapp_s3_grade_user_arn`: User ARN that's used to read from the `grades` bucket
+- `number_of_instances`: Number of ec2 analytics instances, useful for provisioning new ones as we
+  normally use only 1 instance. Defaults to 1
+- `lb_instance_indexes`: List of indexes of the previous instances to be added to the Load Balancer.
+  Defaults to `[0]` (only the first instance)
 
 ## Output
 

--- a/modules/services/analytics/elasticsearch.tf
+++ b/modules/services/analytics/elasticsearch.tf
@@ -32,7 +32,9 @@ module "elasticsearch" {
   zone_awareness_enabled = false
   create_iam_service_linked_role = false
 
-  specific_subnet_ids = aws_instance.analytics.*.subnet_id
+  # TODO: verify this doesn't affect accessibility if we actually use multiple analytics instances
+  # not a problem right now as we are not using multiple analytics instances
+  specific_subnet_ids = [aws_instance.analytics[0].subnet_id]
 
   extra_security_group_ids = [
     # Analytics instance needs to be able to read from Elasticsearch

--- a/modules/services/analytics/elasticsearch.tf
+++ b/modules/services/analytics/elasticsearch.tf
@@ -32,7 +32,7 @@ module "elasticsearch" {
   zone_awareness_enabled = false
   create_iam_service_linked_role = false
 
-  specific_subnet_ids = [aws_instance.analytics.subnet_id]
+  specific_subnet_ids = aws_instance.analytics.*.subnet_id
 
   extra_security_group_ids = [
     # Analytics instance needs to be able to read from Elasticsearch

--- a/modules/services/analytics/main.tf
+++ b/modules/services/analytics/main.tf
@@ -49,8 +49,9 @@ resource "aws_lb_target_group" "analytics_lb_target_group" {
 }
 
 resource aws_lb_target_group_attachment edxapp {
+  count = length(var.lb_instance_indexes)
   target_group_arn = aws_lb_target_group.analytics_lb_target_group.arn
-  target_id = aws_instance.analytics.id
+  target_id = aws_instance.analytics[var.lb_instance_indexes[count.index]].id
   port = 80
 
   lifecycle {
@@ -156,6 +157,7 @@ resource "aws_security_group_rule" "analytics-outbound" {
 
 ######################################################
 resource "aws_instance" "analytics" {
+  count = var.number_of_instances
   ami = var.analytics_image_id
   instance_type = var.analytics_instance_type
   vpc_security_group_ids = [aws_security_group.analytics.id]

--- a/modules/services/analytics/outputs.tf
+++ b/modules/services/analytics/outputs.tf
@@ -9,3 +9,11 @@ output "emr_rds_security_group_id" {
 output "elasticsearch_host" {
   value = module.elasticsearch.elasticsearch
 }
+
+output "analytics_instance_private_ips" {
+  value = aws_instance.analytics.*.private_ip
+}
+
+output "analytics_instance_public_ips" {
+  value = aws_instance.analytics.*.public_ip
+}

--- a/modules/services/analytics/variables.tf
+++ b/modules/services/analytics/variables.tf
@@ -4,8 +4,14 @@ variable "analytics_image_id" {}
 variable "analytics_instance_type" {}
 variable "analytics_key_pair_name" {}
 variable "hosted_zone_domain" {}
+variable "number_of_instances" {
+  default = 1
+}
 variable "instance_iteration" {
   default = 1
+}
+variable "lb_instance_indexes" {
+  default = [0]
 }
 
 variable "analytics_identifier" {


### PR DESCRIPTION
This PR adds multiple instance support for Analytics, mostly useful for when we have to provision a new instance, so it shouldn't be considered that this module actually supports multiple instances (it should, but we haven't confirmed it yet)

**Reviewers:**
- [x] @pomegranited 