### PR TITLE
doc: Adds comments for EMR policy deprecation

### DIFF
--- a/modules/services/analytics/emr.tf
+++ b/modules/services/analytics/emr.tf
@@ -75,7 +75,7 @@ resource "aws_iam_role" "emr_default_role" {
 
 resource "aws_iam_role_policy_attachment" "emr-default-role-attachment" {
   role = aws_iam_role.emr_default_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole"
+  policy_arn = var.emr_service_role_policy
 }
 
 data "aws_iam_policy_document" "ec2-assume-role-policy-2008" {
@@ -98,7 +98,7 @@ resource "aws_iam_role" "emr-ec2-default-role" {
 
 resource "aws_iam_role_policy_attachment" "emr-ec2-default-role-attachment" {
   role = aws_iam_role.emr-ec2-default-role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role"
+  policy_arn = var.emr_ec2_service_role_policy
 }
 
 resource "aws_iam_instance_profile" "emr-ec2-default-role-instance-profile" {

--- a/modules/services/analytics/variables.tf
+++ b/modules/services/analytics/variables.tf
@@ -22,6 +22,24 @@ variable "provision_role_description" {
   default = "Terraform managed - Opencraft"
 }
 
+variable "emr_service_role_policy" {
+  # Deprecated service role, cf
+  # https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-iam-policies.html
+  default = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole"
+
+  # Use for new deployments made after May 1 2020
+  # default = "arn:aws:iam::aws:policy/service-role/AmazonEMRServicePolicy_v2"
+}
+
+variable "emr_ec2_service_role_policy" {
+  # Deprecated service role, cf
+  # https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-iam-policies.html
+  default = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role"
+
+  # No replacement service role was provided for V2.
+  # For new deployments made after May 1 2020, a new policy will need to be created which allows access to the required resources.
+}
+
 variable "emr_master_security_group_description" {
   default = "Managed by Terraform"
 }


### PR DESCRIPTION
AWS EMR default service policies have changed for users and roles created after 1 May 2021.

See:
* https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-deprecated.html
* https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-iam-policies.html
* https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#aws-managed-policies

**Author Notes & Concerns**

* This change does not fully apply the fixes required for these changes, because they will need to be developed and tested on a newly created analytics instance.

  But it does allow existing instances provisioned with the deprecated policies to continue to work, and provides a way for new deployments to specify updated policies.

**Testing instructions**

1. Locate a working Analytics deployment that used terraform (e.g. UBC), and update its `module "analytics"` `source` ref to use this branch.
2. Run `terraform init` and `terraform plan`, and ensure that no changes will be made to the deployment.

**Reviewer**

- [x] @eLRuLL 