### PR TITLE
[FAL-1887] Engine version updated to 5.7.33

### DIFF
--- a/modules/services/sql/variables.tf
+++ b/modules/services/sql/variables.tf
@@ -3,7 +3,7 @@ variable "environment" {}
 
 variable "instance_class" {}
 variable "engine_version" {
-  default = "5.6.48"
+  default = "5.7.33"
 }
 variable "allocated_storage" {}
 variable "max_allocated_storage" {


### PR DESCRIPTION
The version of the engine was updated to `5.7.33` to be the same of the analytics version in this task [FAL-1887](https://tasks.opencraft.com/browse/FAL-1887)

**Reviewers:**

- [ ] @eLRuLL 

