### PR TITLE
feat: use custom VPCs for Analytics module

### DIFF
--- a/modules/services/analytics/README.md
+++ b/modules/services/analytics/README.md
@@ -31,6 +31,11 @@ https://github.com/open-craft/openedx-deployment/blob/master/docs/analytics/AWS_
   normally use only 1 instance. Defaults to 1
 - `lb_instance_indexes`: List of indexes of the previous instances to be added to the Load Balancer.
   Defaults to `[0]` (only the first instance)
+- `use_route53`: Allows disabling Route 53 setup when using external DNS. Defaults to `true`.
+- `extended_instance_name`: Allows naming analytics instances with a similar pattern that other resources use.
+  Defaults to `false` for backward compatibility.
+- `aws_vpc_id`: The ID of the AWS VPC that should contain all resources.
+  Defaults to an empty string - the default VPC is used in such case.
 
 ## Output
 

--- a/modules/services/analytics/elasticsearch.tf
+++ b/modules/services/analytics/elasticsearch.tf
@@ -32,6 +32,7 @@ module "elasticsearch" {
   zone_awareness_enabled = false
   create_iam_service_linked_role = false
 
+  specific_vpc_id = var.aws_vpc_id
   # TODO: verify this doesn't affect accessibility if we actually use multiple analytics instances
   # not a problem right now as we are not using multiple analytics instances
   specific_subnet_ids = [aws_instance.analytics[0].subnet_id]

--- a/modules/services/analytics/emr.tf
+++ b/modules/services/analytics/emr.tf
@@ -111,6 +111,7 @@ resource "aws_iam_instance_profile" "emr-ec2-default-role-instance-profile" {
 resource "aws_security_group" "emr-master" {
   name = "ElasticMapReduce-master"
   description = var.emr_master_security_group_description
+  vpc_id = local.vpc_id
 }
 
 resource "aws_security_group_rule" "emr-master-tcp-same-inbound" {
@@ -205,6 +206,7 @@ resource "aws_security_group_rule" "emr-master-analytics-inbound" {
 resource "aws_security_group" "emr-slave" {
   name = "ElasticMapReduce-slave"
   description = var.emr_slave_security_group_description
+  vpc_id = local.vpc_id
 }
 
 resource "aws_security_group_rule" "emr-slave-tcp-same-inbound" {

--- a/modules/services/analytics/rds.tf
+++ b/modules/services/analytics/rds.tf
@@ -1,5 +1,6 @@
 resource "aws_security_group" "emr-rds" {
   name = "EMR RDS"
+  vpc_id = local.vpc_id
 }
 
 resource "aws_security_group_rule" "emr-rds-master-inbound" {

--- a/modules/services/analytics/variables.tf
+++ b/modules/services/analytics/variables.tf
@@ -58,6 +58,24 @@ variable "edxapp_s3_grade_bucket_id" {}
 variable "edxapp_s3_grade_bucket_arn" {}
 variable "edxapp_s3_grade_user_arn" {}
 
+variable "use_route53" {
+  description = "Allows disabling Route 53 setup when using external DNS."
+  type        = bool
+  default     = true
+}
+
+variable "extended_instance_name" {
+  description = "Allows naming analytics instances with a similar pattern that other resources use."
+  type        = bool
+  default     = false
+}
+
+variable "aws_vpc_id" {
+  description = "The ID of the AWS VPC that should contain all resources. If not specified, the default VPC is used."
+  type        = string
+  default     = ""
+}
+
 locals {
   http_port = 80
   https_port = 443

--- a/modules/services/elasticsearch/main.tf
+++ b/modules/services/elasticsearch/main.tf
@@ -1,10 +1,9 @@
 locals {
-  vpc_id = var.specific_vpc_id != "" ? var.specific_vpc_id : data.aws_vpc.default[0].id
+  vpc_id = var.specific_vpc_id != "" ? var.specific_vpc_id : data.aws_vpc.default.id
 }
 
 data "aws_vpc" "default" {
   default = true
-  count = length(var.specific_subnet_ids) > 0 ? 0 : 1
 }
 
 data "aws_subnet_ids" "default" {
@@ -15,8 +14,16 @@ data "aws_subnet_ids" "default" {
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
+locals {
+  # This name cannot be longer than 28 characters.
+  # We want to use the long name by default to avoid breaking backward compatibility.
+  es_long_domain_name = "${var.customer_name}-${var.environment}-elasticsearch"
+  es_short_domain_name = "${var.customer_name}-${var.environment}-es"
+  es_domain_name = length(local.es_long_domain_name) <= 28 ? local.es_long_domain_name : local.es_short_domain_name
+}
+
 resource aws_elasticsearch_domain "openedx" {
-  domain_name = "${var.customer_name}-${var.environment}-elasticsearch"
+  domain_name = local.es_domain_name
   elasticsearch_version = "1.5"
 
   cluster_config {


### PR DESCRIPTION
Jira ticket: [BB-4839](https://tasks.opencraft.com/browse/BB-4839)

This includes the following changes:
1. Optionally disable Route 53 for analytics. This is useful when the DNS is managed externally.
2. Enable unified EC2 instance naming for analytics and ElasticSearch.
3. Optionally specify AWS VPC for analytics.
4. Fix ElasticSearch fallback to the default VPC.