### PR TITLE
feat: modify default cdn cache behavior [BB-5128]

### DIFF
--- a/optional/cloudfront_cdn/main.tf
+++ b/optional/cloudfront_cdn/main.tf
@@ -22,24 +22,24 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   }
 
   default_cache_behavior {
-    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = var.origin_domain
 
     default_ttl            = var.cache_expiration
     max_ttl                = var.cache_expiration
     compress               = true
-    viewer_protocol_policy = "allow-all"
+    viewer_protocol_policy = "redirect-to-https"
 
     forwarded_values {
       query_string = true
 
       headers = [
-        "*",
+        "Origin",
       ]
 
       cookies {
-        forward           = "none"
+        forward = "none"
       }
     }
   }

--- a/optional/cloudfront_cdn/variables.tf
+++ b/optional/cloudfront_cdn/variables.tf
@@ -21,5 +21,5 @@ variable "origin_domain" {
 variable "cache_expiration" {
   description = "Time of cache expiration in seconds."
   type = number
-  default = 3600
+  default = 31536000
 }


### PR DESCRIPTION
## Description
Made changes to terraform configs, so that infrastructure changes related to CDN setup can be managed using terraform.

Modified default CloudFront CDN behavior:
- Removed "OPTION" from allowed methods
- Changed "Viewer protocol policy" to `Redirect HTTP to HTTPS`
- Changed "Cache expiration" to 0
- Added "default cache policy" resource, that is created and used by the default cache behavior

To import existing cdn cache policy into state:
```
terraform import aws_cloudfront_cache_policy.default_cache_policy <cache_policy_id>
```