### PR TITLE
feat: allow specifying elasticsearch version [BB-4724]

### DIFF
--- a/modules/services/elasticsearch/README.md
+++ b/modules/services/elasticsearch/README.md
@@ -9,6 +9,8 @@ group for the OpenedX instance.
 - `customer_name`: the customer's name, this variable is used for resource naming
 - `environment`: `prod` for example, this variable is used for resource naming
 - `edxapp_security_group_id`: and AWS security group id, It should be the one configured for your OpenedX instance.
+- `elasticsearch_version`: defaults to `1.5`
+- `elasticsearch_instance_type`: defaults to `t2.small.elasticsearch`
 - `zone_awareness_enabled`: Indicates whether zone awareness is enabled in the ES domain. Defaults to `true`
 - `availability_zone_count`: Used if `zone_awareness_enabled` is `true`, sets the number of Availability Zones
   to be used. Defaults to `2`

--- a/modules/services/elasticsearch/main.tf
+++ b/modules/services/elasticsearch/main.tf
@@ -24,7 +24,7 @@ locals {
 
 resource aws_elasticsearch_domain "openedx" {
   domain_name = local.es_domain_name
-  elasticsearch_version = "1.5"
+  elasticsearch_version = var.elasticsearch_version
 
   cluster_config {
     instance_count = var.instance_count

--- a/modules/services/elasticsearch/variables.tf
+++ b/modules/services/elasticsearch/variables.tf
@@ -1,6 +1,9 @@
 variable "customer_name" {}
 variable "environment" {}
 variable "edxapp_security_group_id" {}
+variable "elasticsearch_version" {
+  default = "1.5"
+}
 variable "elasticsearch_instance_type" {
   default = "t2.small.elasticsearch"
 }


### PR DESCRIPTION
This allows specifying the ES version because ES 7 is needed for Lilac. It has a default value of `1.5` to preserve backward compatibility.