### PR TITLE
feat: expose openedx app load balancer idle timeout [BB-5349]

### DIFF
--- a/modules/openedx/application/load-balancer.tf
+++ b/modules/openedx/application/load-balancer.tf
@@ -2,6 +2,7 @@ resource "aws_lb" "application" {
   name               = local.load_balancer_name
   load_balancer_type = "application"
   subnets            = data.aws_subnet_ids.subnets.ids
+  idle_timeout       = var.load_balancer_idle_timeout
   security_groups = [
     aws_security_group.edxapp_appserver.id
   ]

--- a/modules/openedx/application/variables.tf
+++ b/modules/openedx/application/variables.tf
@@ -287,3 +287,10 @@ variable "enable_course_discovery" {
   type        = bool
   default     = false
 }
+
+### Load Balancer Settings ###############################
+variable "load_balancer_idle_timeout" {
+  description = "The time in seconds that the Load Balancer will allow the connection to be idle."
+  type        = number
+  default     = 60
+}


### PR DESCRIPTION
## Description

This exposes the idle_timeout value of the application AWS LB as
a variable, allowing the idle_timeout value to be customized per
deployment instead of the default 60 seconds.

## Additional information

JIRA Ticket: [BB-5349](https://tasks.opencraft.com/browse/BB-5349)