### PR TITLE
feat: add rds instance id as output [BB-5321]

### DIFF
--- a/modules/services/sql/README.md
+++ b/modules/services/sql/README.md
@@ -24,3 +24,4 @@ AWS Security Group
 ## Output
 
 - `mysql_host_name`: MySQL instance Endpoint. To be set in the `EDXAPP_MYSQL_HOST` variable
+- `mysql_instance_id`: MySQL instance id. To be used to setup CloudWatch alarms

--- a/modules/services/sql/outputs.tf
+++ b/modules/services/sql/outputs.tf
@@ -1,3 +1,7 @@
 output "mysql_host_name" {
   value = aws_db_instance.mysql_rds.endpoint
 }
+
+output "mysql_instance_id" {
+  value = aws_db_instance.mysql_rds.id
+}


### PR DESCRIPTION
## Description

This PR adds rds instance id as output for the sql module.

This change is already introduced in `main` branch in [PR#31](https://github.com/open-craft/terraform-scripts/pull/31).
It is being added it `uq-staging` branch seperately, so that it can be used in UQ instances.

## Supporting information

[BB-5321](https://tasks.opencraft.com/browse/BB-5321)
