### PR TITLE
feat: allow using custom CDN domains [BB-5431]

### DIFF
--- a/modules/services/openedx/outputs.tf
+++ b/modules/services/openedx/outputs.tf
@@ -5,3 +5,8 @@ output "edxapp_security_group_id" {
 output "edxapp_lb_target_group_arn" {
   value = aws_lb_target_group.edxapp.arn
 }
+
+output "route53_zone_id" {
+  value       = var.route53_create_main_domain ? aws_route53_record.main_domain_lb_record[0].zone_id : null
+  description = "The ID of the zone in which the main domain was created (**if** it was created)."
+}

--- a/optional/cloudfront_cdn/README.md
+++ b/optional/cloudfront_cdn/README.md
@@ -1,6 +1,6 @@
 # AWS CDN Setup for static asset caching
 
-This configures an AWS CDN using Cloudfront to cache assets from a given origin URL.
+This configures an AWS CDN using CloudFront to cache assets from a given origin URL.
 This can be used to cache assets from an Open edX instance or a marketing website.
 
 ## How to use
@@ -23,17 +23,26 @@ Configure the inputs as described below:
 - `origin_domain`: domain of the static file origins that the CDN should pull from.
     Example: `my-instance.example.com` (LMS domain name)
 - `cache_expiration` (optional): time of cache expiration in seconds.
+- `aliases` (optional): a list of domain aliases for the CDN
 
 2. Set up the outputs on your client's TF files by adding this section:
 ```
-output "output_openedx_cdn" {
-  value = module.openedx_cdn.aws_cloudfront_distribution
+output "openedx_cdn_domain_name" {
+  value = module.openedx_cdn.aws_cloudfront_distribution.domain_name
 }
 ```
 
 3. Run terraform apply and add the following outputs of this module to the `vars.yml` ansible variable file:
-- `EDXAPP_LMS_STATIC_URL_BASE`: retrieve the value `output_openedx_cdn.domain_name` from the output of this module.
+- `EDXAPP_LMS_STATIC_URL_BASE`: retrieve the value `openedx_cdn_domain_name` from the output of this module.
 
+## Custom CDN domain
+
+You can use a custom domain (alias) for the CloudFront distribution by configuring the following optional variables:
+1. `aliases`:  A list of aliases that will can be used instead of the Cloudfront distribution's domain.
+2. `alias_zone_id`: ID of the Route 53 zone, in which an alias subdomain should be created. Set this if you want the subdomain to be created automatically.
+3. `alias_name: `: Prefix for the CDN subdomain. Default: `cdn`.
+4. `alias_certificate_arn`: Set this if you have an existing ACM certificate in the `us-east-1` region. Otherwise, a new certificate will be created.
+5. `aws_provider_profile`: Set this if you haven't set `alias_certificate_arn`. It determines the source environment for the AWS credentials.
 
 ## TODOS
 

--- a/optional/cloudfront_cdn/README.md
+++ b/optional/cloudfront_cdn/README.md
@@ -38,7 +38,7 @@ output "openedx_cdn_domain_name" {
 ## Custom CDN domain
 
 You can use a custom domain (alias) for the CloudFront distribution by configuring the following optional variables:
-1. `aliases`:  A list of aliases that will can be used instead of the Cloudfront distribution's domain.
+1. `aliases`:  A list of aliases that can be used instead of the Cloudfront distribution's domain.
 2. `alias_zone_id`: ID of the Route 53 zone, in which an alias subdomain should be created. Set this if you want the subdomain to be created automatically.
 3. `alias_name: `: Prefix for the CDN subdomain. Default: `cdn`.
 4. `alias_certificate_arn`: Set this if you have an existing ACM certificate in the `us-east-1` region. Otherwise, a new certificate will be created.

--- a/optional/cloudfront_cdn/main.tf
+++ b/optional/cloudfront_cdn/main.tf
@@ -1,7 +1,15 @@
+# Custom aliases require setting a custom ACM certificate, which needs to be in the `us-east-1` region.
+provider "aws" {
+  alias   = "acm"
+  region  = "us-east-1"
+  profile = var.aws_provider_profile
+}
+
 resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   enabled             = true
   is_ipv6_enabled     = true
   comment             = lower(join("-", [var.client_shortname, var.environment, var.service_name]))
+  aliases             = var.aliases
 
   origin {
     domain_name         = var.origin_domain
@@ -55,6 +63,83 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    # This part is very ugly because there are 3 typical use cases:
+    #   1. Using the default certificate domain.
+    #      In this case, no additional resources are needed because the CloudFront default certificate is sufficient.
+    #   2. Use the existing ACM certificate from the `us-east-1` region.
+    #      In this case, only the domain record is created.
+    #   3. Generate a new ACM certificate in the `us-east-1` region.
+    #      Applicable when the main certificate already exists in another region.
+    cloudfront_default_certificate = var.aliases == null ? true : false
+
+    acm_certificate_arn = (
+                            var.aliases == null
+                              ? null
+                              : var.alias_certificate_arn == null
+                                ? aws_acm_certificate.alias_certificate[0].arn
+                                  : var.alias_certificate_arn
+                          )
+    # Needs to be set along with the non-default certificate.
+    ssl_support_method = var.aliases == null ? null : "sni-only"
   }
+}
+
+
+# Custom CDN subdomain.
+resource "aws_route53_record" alias {
+  count = var.alias_zone_id == null ? 0 : 1
+
+  zone_id = var.alias_zone_id
+  name    = var.alias_name
+  type    = "A"
+
+  alias {
+    name    = aws_cloudfront_distribution.cloudfront_distribution.domain_name
+    zone_id = aws_cloudfront_distribution.cloudfront_distribution.hosted_zone_id
+
+    evaluate_target_health = false
+  }
+}
+
+# Custom ACM certificate.
+resource "aws_acm_certificate" alias_certificate {
+  count = var.alias_zone_id != null && var.alias_certificate_arn == null ? 1 : 0
+  provider = aws.acm
+
+  domain_name       = "${var.alias_name}.${var.origin_domain}"
+  validation_method = "DNS"
+}
+
+locals {
+  domain_validation_options = (length(aws_acm_certificate.alias_certificate) > 0
+                                 ? aws_acm_certificate.alias_certificate[0].domain_validation_options
+                                 : []
+                              )
+}
+
+resource aws_route53_record alias_validation_records {
+  for_each = {
+    for dvo in local.domain_validation_options : dvo.domain_name => {
+      name = dvo.resource_record_name
+    record = dvo.resource_record_value
+    type   = dvo.resource_record_type
+  }
+  }
+
+  allow_overwrite = true
+  zone_id = var.alias_zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 60
+  records = [
+    each.value.record
+  ]
+}
+
+resource "aws_acm_certificate_validation" alias_domain_validation {
+  provider = aws.acm
+  count    = length(aws_acm_certificate.alias_certificate)
+
+  certificate_arn         = aws_acm_certificate.alias_certificate[0].arn
+  validation_record_fqdns = [for record in aws_route53_record.alias_validation_records : record.fqdn]
 }

--- a/optional/cloudfront_cdn/main.tf
+++ b/optional/cloudfront_cdn/main.tf
@@ -75,9 +75,9 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
     acm_certificate_arn = (
                             var.aliases == null
                               ? null
-                              : var.alias_certificate_arn == null
-                                ? aws_acm_certificate.alias_certificate[0].arn
-                                  : var.alias_certificate_arn
+                              : var.alias_certificate_arn != null
+                                ? var.alias_certificate_arn
+                                  : aws_acm_certificate.alias_certificate[0].arn
                           )
     # Needs to be set along with the non-default certificate.
     ssl_support_method = var.aliases == null ? null : "sni-only"
@@ -121,9 +121,9 @@ resource aws_route53_record alias_validation_records {
   for_each = {
     for dvo in local.domain_validation_options : dvo.domain_name => {
       name = dvo.resource_record_name
-    record = dvo.resource_record_value
-    type   = dvo.resource_record_type
-  }
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
   }
 
   allow_overwrite = true

--- a/optional/cloudfront_cdn/main.tf
+++ b/optional/cloudfront_cdn/main.tf
@@ -6,14 +6,14 @@ provider "aws" {
 }
 
 resource "aws_cloudfront_distribution" "cloudfront_distribution" {
-  enabled             = true
-  is_ipv6_enabled     = true
-  comment             = lower(join("-", [var.client_shortname, var.environment, var.service_name]))
-  aliases             = var.aliases
+  enabled         = true
+  is_ipv6_enabled = true
+  comment         = lower(join("-", [var.client_shortname, var.environment, var.service_name]))
+  aliases         = var.aliases
 
   origin {
-    domain_name         = var.origin_domain
-    origin_id           = var.origin_domain
+    domain_name = var.origin_domain
+    origin_id   = var.origin_domain
 
     custom_origin_config {
       http_port                = 80
@@ -77,7 +77,7 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
                               ? null
                               : var.alias_certificate_arn != null
                                 ? var.alias_certificate_arn
-                                  : aws_acm_certificate.alias_certificate[0].arn
+                                : aws_acm_certificate.alias_certificate[0].arn
                           )
     # Needs to be set along with the non-default certificate.
     ssl_support_method = var.aliases == null ? null : "sni-only"
@@ -103,7 +103,7 @@ resource "aws_route53_record" alias {
 
 # Custom ACM certificate.
 resource "aws_acm_certificate" alias_certificate {
-  count = var.alias_zone_id != null && var.alias_certificate_arn == null ? 1 : 0
+  count    = var.alias_zone_id != null && var.alias_certificate_arn == null ? 1 : 0
   provider = aws.acm
 
   domain_name       = "${var.alias_name}.${var.origin_domain}"
@@ -120,13 +120,14 @@ locals {
 resource aws_route53_record alias_validation_records {
   for_each = {
     for dvo in local.domain_validation_options : dvo.domain_name => {
-      name = dvo.resource_record_name
+      name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
   }
 
   allow_overwrite = true
+
   zone_id = var.alias_zone_id
   name    = each.value.name
   type    = each.value.type

--- a/optional/cloudfront_cdn/variables.tf
+++ b/optional/cloudfront_cdn/variables.tf
@@ -23,3 +23,33 @@ variable "cache_expiration" {
   type = number
   default = 31536000
 }
+
+variable "aliases" {
+  description = "A list of aliases that will can be used instead of the CloudFront distribution's domain."
+  type = list(string)
+  default = null
+}
+
+variable "alias_zone_id" {
+  description = "ID of the Route 53 zone, in which an alias subdomain should be created. Set this if you want the subdomain to be created automatically."
+  type = string
+  default = null
+}
+
+variable "alias_name" {
+  description = "Prefix for the CDN subdomain."
+  type = string
+  default = "cdn"
+}
+
+variable "alias_certificate_arn" {
+  description = "Set this if you have an existing ACM certificate in the `us-east-1` region. Otherwise, a new certificate will be created."
+  type = string
+  default = null
+}
+
+variable "aws_provider_profile" {
+  description = "Set this if you haven't set `alias_certificate_arn`. It determines the source environment for the AWS credentials."
+  type = string
+  default = null
+}


### PR DESCRIPTION
This adds support for using custom domains with CloudFront CDN.

Rationale: in Open edX, the "text" plugin from RequireJS [doesn't use XmlHttpRequest by default](https://github.com/requirejs/text#xhr-restrictions). This results in adding a `.js` suffix to addresses from different domains. There are three workarounds:
1. Use a subdomain as the CDN alias.
2. Set this in the `require-config.js` (e.g. with a comprehensive theme):
   ```
    config: {
        text: {
            useXhr: function(url, protocol, hostname, port) {
                return true;
            }
        }
    },
   ```
3. Create a Lambda function to rewrite URLs.

This PR allows enables the first approach for `terraform-scripts` users.