### PR TITLE
feat: adds script to setup cloudwatch for server logs

### DIFF
--- a/modules/services/cloudwatch/ec2-server-log.tf
+++ b/modules/services/cloudwatch/ec2-server-log.tf
@@ -1,0 +1,83 @@
+
+data aws_iam_policy_document cloudwatch_log_policy {
+  statement {
+      actions = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams"
+      ]
+      resources = ["*"]
+  }
+}
+
+resource aws_iam_policy cloudwatch_server_log_policy {
+  count       = length(var.ec2_instances)
+  name        = "${element(var.ec2_instances, count.index)}-${var.environment}-cloudwatch-log-policy"
+  description = "cloudwatch-log policy"
+
+  policy = data.aws_iam_policy_document.cloudwatch_log_policy.json
+}
+
+resource aws_iam_role cloudwatch_server_log_role {
+  count              = length(var.ec2_instances)
+  name               = "${element(var.ec2_instances, count.index)}-${var.environment}-log-role"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+    }
+  ]
+}
+EOF
+}
+
+resource aws_iam_role_policy_attachment role_policy_attach {
+  role       = aws_iam_role.cloudwatch_server_log_role.name
+  policy_arn = aws_iam_policy.cloudwatch_server_log_policy.arn
+}
+
+resource aws_iam_instance_profile ec2_log_profile {
+  name = "log-profile"
+  role = aws_iam_role.role.name
+}
+
+
+resource aws_cloudwatch_log_group server_log_group
+  tags              =  {
+    Name = "Server log"
+  }
+}
+resource aws_cloudwatch_log_resource_policy "openedx" {
+  policy_name = "openedx-cloudwatch-log-resource-policy"
+
+  policy_document = jsonencode({
+    Version = "2012-10-17"
+    Statement = {
+      Effect = "Allow"
+      Principal = {
+        Service = "es.amazonaws.com"
+      },
+      Action = [
+        "logs:PutLogEvents",
+        "logs:PutLogEventsBatch",
+        "logs:CreateLogStream",
+        "logs:CreateLogGroup",
+        "logs:DescribeLogStreams"
+      ],
+      Resource = ["*"]
+    }
+  })
+}
+
+resource aws_cloudwatch_log_stream log_stream {
+  count          = length(var.ec2_instances)
+  name           = "${element(var.ec2_instances, count.index)}-${var.environment}-server-log-stream"
+  log_group_name = aws_cloudwatch_log_group.server_log_group.name
+}

--- a/modules/services/cloudwatch/ec2-server-log.tf
+++ b/modules/services/cloudwatch/ec2-server-log.tf
@@ -1,4 +1,3 @@
-
 data aws_iam_policy_document cloudwatch_log_policy {
   statement {
       actions = [
@@ -12,51 +11,48 @@ data aws_iam_policy_document cloudwatch_log_policy {
 }
 
 resource aws_iam_policy cloudwatch_server_log_policy {
-  count       = length(var.ec2_instances)
-  name        = "${element(var.ec2_instances, count.index)}-${var.environment}-cloudwatch-log-policy"
+  name = "${var.customer_name}-${var.environment}-cloudwatch-log-policy"
   description = "cloudwatch-log policy"
 
   policy = data.aws_iam_policy_document.cloudwatch_log_policy.json
 }
 
 resource aws_iam_role cloudwatch_server_log_role {
-  count              = length(var.ec2_instances)
-  name               = "${element(var.ec2_instances, count.index)}-${var.environment}-log-role"
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
+  name = "${var.customer_name}-${var.environment}-log-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
       },
-      "Effect": "Allow",
-    }
-  ]
-}
-EOF
+    ]
+  })
 }
 
 resource aws_iam_role_policy_attachment role_policy_attach {
-  role       = aws_iam_role.cloudwatch_server_log_role.name
+  role = aws_iam_role.cloudwatch_server_log_role.name
   policy_arn = aws_iam_policy.cloudwatch_server_log_policy.arn
 }
 
-resource aws_iam_instance_profile ec2_log_profile {
-  name = "log-profile"
-  role = aws_iam_role.role.name
+resource aws_iam_instance_profile server_logs_profile {
+  name = "${var.customer_name}-${var.environment}-log-profile"
+  role = aws_iam_role.cloudwatch_server_log_role.name
 }
 
 
-resource aws_cloudwatch_log_group server_log_group
-  tags              =  {
-    Name = "Server log"
+resource aws_cloudwatch_log_group server_log_group {
+  tags = {
+    Name = "${var.customer_name}-${var.environment}-server-log-group"
   }
 }
-resource aws_cloudwatch_log_resource_policy "openedx" {
-  policy_name = "openedx-cloudwatch-log-resource-policy"
 
+resource aws_cloudwatch_log_resource_policy openedx_cloudwatch_log_resource_policy {
+  policy_name = "${var.customer_name}-${var.environment}-cloudwatch-log-resource-policy"
   policy_document = jsonencode({
     Version = "2012-10-17"
     Statement = {
@@ -77,7 +73,6 @@ resource aws_cloudwatch_log_resource_policy "openedx" {
 }
 
 resource aws_cloudwatch_log_stream log_stream {
-  count          = length(var.ec2_instances)
-  name           = "${element(var.ec2_instances, count.index)}-${var.environment}-server-log-stream"
+  name = "${var.customer_name}-${var.environment}-server-log-stream"
   log_group_name = aws_cloudwatch_log_group.server_log_group.name
 }

--- a/modules/services/cloudwatch/outputs.tf
+++ b/modules/services/cloudwatch/outputs.tf
@@ -5,3 +5,7 @@ output "low_priority_alert_arn" {
 output "high_priority_alert_arn" {
   value = aws_sns_topic.high_priority_alert.arn
 }
+
+output "server_logs_profile_name" {
+  value = aws_iam_instance_profile.server_logs_profile.name
+}


### PR DESCRIPTION
## Description

This PR adds terraform script to setup cloudwatch to receive server logs from EC2 instances.

**Link to ticket**: https://tasks.opencraft.com/browse/BB-6085

## Testing instruction
(Pull the changes of this PR)
- Add a `aws_instance` resource having `iam_instance_profile = aws_iam_instance_profile.ec2_log_profile.name`
- Use the module (ec2_server_log) added in this PR.
- Run `terraform apply` command and create a new ec2 instance

([Setup aws log agent](https://github.com/open-craft/ansible-playbooks/pull/279) to send logs to server)

## Screenshot
![image](https://user-images.githubusercontent.com/16653571/163807671-49c25b7f-a72a-4fcf-90bd-f69ab44e00f0.png)
