### PR TITLE
[BB-6232] feat: add permissive response headers policy

### DIFF
--- a/optional/cloudfront_cdn/main.tf
+++ b/optional/cloudfront_cdn/main.tf
@@ -51,6 +51,35 @@ resource "aws_cloudfront_origin_request_policy" "origin_request_policy" {
   }
 }
 
+resource "aws_cloudfront_response_headers_policy" "response_headers_policy" {
+  name    = lower(join("-", [var.client_shortname, var.environment, var.service_name, "cdn-response-headers-policy"]))
+  comment = lower(join("-", [var.client_shortname, var.environment, var.service_name]))
+
+  cors_config {
+    access_control_allow_credentials = false
+    access_control_max_age_sec       = var.cache_expiration
+    origin_override                  = true
+
+    access_control_allow_headers {
+      items = [
+        "*",
+      ]
+    }
+
+    access_control_allow_methods {
+      items = [
+        "ALL",
+      ]
+    }
+
+    access_control_allow_origins {
+      items = [
+        "*",
+      ]
+    }
+  }
+}
+
 resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   enabled         = true
   is_ipv6_enabled = true
@@ -82,9 +111,10 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
 
     compress = true
 
-    viewer_protocol_policy   = "redirect-to-https"
-    cache_policy_id          = aws_cloudfront_cache_policy.cache_policy.id
-    origin_request_policy_id = aws_cloudfront_origin_request_policy.origin_request_policy.id
+    viewer_protocol_policy     = "redirect-to-https"
+    cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
+    origin_request_policy_id   = aws_cloudfront_origin_request_policy.origin_request_policy.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
   }
 
   restrictions {


### PR DESCRIPTION
### Description

Without setting response headers policy explicitly, responses from CloudFront CDN either are [missing Access-Control-Allow-Origin header][1] or have it's value [set to "null", which should not be used][2].

Both cases lead to browsers blocking the requests to CDN. Adding permissive policy forces CDN to respond with:

```
Access-Control-Allow-Origin: *
```

which let's the browser know to not block the request to CDN.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSMissingAllowOrigin
[2]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin

### Links

[BB-6232](https://tasks.opencraft.com/browse/BB-6232)

### Testing

Similar changes have been tested for different client.