### PR TITLE
feat: allow specifying es version for analytics

### DIFF
--- a/modules/services/analytics/README.md
+++ b/modules/services/analytics/README.md
@@ -22,6 +22,7 @@ https://github.com/open-craft/openedx-deployment/blob/master/docs/analytics/AWS_
 - `provision_role_description`(optional): Description of the role used for the EC2 analytics instance
 - `emr_master_security_group_description`(optional): Description of the EMR master Security Group
 - `emr_slave_security_group_description`(optional): Description of the EMR slave Security Group
+- `elasticsearch_version`(optional): Analytics elastic search version, default to `1.5`
 - `edxapp_rds_port`: Port to be opened on the RDS security group, defaults to `3306`
 - `director_security_group_id`: The director security group ID used also for setting up the edX instance
 - `edxapp_s3_grade_bucket_id`: bucket ID of the `grades` bucket used for the edX instance

--- a/modules/services/analytics/elasticsearch.tf
+++ b/modules/services/analytics/elasticsearch.tf
@@ -25,6 +25,7 @@ module "elasticsearch" {
   customer_name = var.customer_name
   edxapp_security_group_id = aws_security_group.analytics.id
   environment = var.environment
+  elasticsearch_version = var.elasticsearch_version
 
   number_of_nodes = 1
   instance_count = 1

--- a/modules/services/analytics/variables.tf
+++ b/modules/services/analytics/variables.tf
@@ -48,6 +48,10 @@ variable "emr_slave_security_group_description" {
   default = "Managed by Terraform"
 }
 
+variable "elasticsearch_version" {
+  default = "1.5"
+}
+
 variable "edxapp_rds_port" {
   default = 3306
 }


### PR DESCRIPTION
## Description

PR #29 allowed the elasticseach version to be configurable.

This PR add the capablity to specify the elasticseach version for analytics, which is then passed on to the elasticsearch module. "1.5" is used as the default value for backwards compatibility

## Other information

Private Ref: [BB-6316](https://tasks.opencraft.com/browse/BB-6316)