### PR TITLE
feat: auto select subnet id if default vpc used

### DIFF
--- a/modules/services/analytics/main.tf
+++ b/modules/services/analytics/main.tf
@@ -172,6 +172,7 @@ locals {
   instance_legacy_name = "analytics-${var.instance_iteration}"
   instance_extended_name = join("-", [var.customer_name, var.environment, var.instance_iteration])
   instance_name = var.extended_instance_name ? local.instance_extended_name : local.instance_legacy_name
+  subnet_id = var.aws_vpc_id != "" ? tolist(data.aws_subnet_ids.default.ids)[0] : null
 }
 
 ######################################################
@@ -180,7 +181,7 @@ resource "aws_instance" "analytics" {
   ami = var.analytics_image_id
   instance_type = var.analytics_instance_type
   vpc_security_group_ids = [aws_security_group.analytics.id]
-  subnet_id = tolist(data.aws_subnet_ids.default.ids)[0]
+  subnet_id = local.subnet_id
 
   iam_instance_profile = aws_iam_instance_profile.provision-role-instance-profile.name
 
@@ -193,5 +194,9 @@ resource "aws_instance" "analytics" {
 
   tags = {
     Name = local.instance_name
+  }
+
+  lifecycle {
+    ignore_changes = [subnet_id]
   }
 }


### PR DESCRIPTION
In PR #27, we added the capability to optionally specify custom AWS VPC for analytics.

As part of this, we fetched all the subnet ids present in the VPC and selected the [first subnet id](https://github.com/open-craft/terraform-scripts/blob/32ab4640b92979638449e202d48e0c29eb2adf47/modules/services/analytics/main.tf#L183), from the list of subnet ids for setting up the analytics instance. This was required so that the instance is set up in the specified VPC and not in the default VPC.

However, this presented a problem, if a custom VPC is not used and there are different subnets configured in the default VPC belonging to different availability zones(as is the practice) and the required instance type (eg. `t2.medium`) is not available for the availability zone of the first subnet in the list.

In this PR, we are not setting the subnet id (setting `null` subnet id) for the instance if a custom AWS VPC is not specified, i.e. if the default VPC is used, so that the appropriate subnet is automatically selected during instance setup.

This is assuming that if we pass a custom VPC for analytics, we would setup the subnet in the correct availability zone, which may not be possible for default VPC as other resources(not related to analytics) may be using subnet from other availability zones.

OpenCraft internal ticket: [BB-6136](https://tasks.opencraft.com/browse/BB-6316)