### PR TITLE
feat: make EBS volumes configurable for Director and Analytics [BB-6358]

### DIFF
--- a/modules/services/analytics/README.md
+++ b/modules/services/analytics/README.md
@@ -18,6 +18,13 @@ https://github.com/open-craft/openedx-deployment/blob/master/docs/analytics/AWS_
 - `hosted_zone_domain`: Hosted Zone domain to create the insights subdomain in. This is normally 
   same as the LMS domain
 - `instance_iteration`: Iteration number of the analytics EC2 instance, starts at 1
+- `instance_ebs_volume_type`: Type of EBS volumes attached to the EC2 instance. Defaults to "gp2".
+- `instance_ebs_volume_size`: Size of EBS volumes attached to the EC2 instance (in GiB). Defaults to 50.
+- `instance_ebs_iops`: Baseline input/output (I/O) performance of EBS volumes attached to the EC2 instance. Applicable only if `instance_ebs_volume_type` is set to "gp3". Defaults to 3000.
+- `elasticsearch_instance_type`: Instance type of ElasticSearch data nodes. Defaults to "t2.small.elasticsearch".
+- `elasticsearch_ebs_volume_type`: Type of EBS volumes attached to data nodes. Defaults to "gp2".
+- `elasticsearch_ebs_volume_size`: Size of EBS volumes attached to data nodes (in GiB). Defaults to 10.
+- `elasticsearch_ebs_iops`: Baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only if `ebs_volume_type` is set to "gp3". Defaults to 3000.
 - `analytics_identifier`: Just an identifier for several resource names, defaults to `analytics_identifier`
 - `provision_role_description`(optional): Description of the role used for the EC2 analytics instance
 - `emr_master_security_group_description`(optional): Description of the EMR master Security Group

--- a/modules/services/analytics/elasticsearch.tf
+++ b/modules/services/analytics/elasticsearch.tf
@@ -27,11 +27,17 @@ module "elasticsearch" {
   environment = var.environment
   elasticsearch_version = var.elasticsearch_version
 
+  elasticsearch_instance_type = var.elasticsearch_instance_type
+
   number_of_nodes = 1
   instance_count = 1
   dedicated_master_enabled = false
   zone_awareness_enabled = false
   create_iam_service_linked_role = false
+
+  ebs_volume_type = var.elasticsearch_ebs_volume_type
+  ebs_volume_size = var.elasticsearch_ebs_volume_size
+  ebs_iops        = var.elasticsearch_ebs_iops
 
   specific_vpc_id = var.aws_vpc_id
   # TODO: verify this doesn't affect accessibility if we actually use multiple analytics instances

--- a/modules/services/analytics/main.tf
+++ b/modules/services/analytics/main.tf
@@ -186,8 +186,12 @@ resource "aws_instance" "analytics" {
   key_name = var.analytics_key_pair_name
 
   root_block_device {
-    volume_size = 50
-    volume_type = "gp2"
+    volume_type = var.instance_ebs_volume_type
+    volume_size = var.instance_ebs_volume_size
+    iops        = var.instance_ebs_volume_type == "gp3" ? var.instance_ebs_iops : null
+    tags = {
+      Name = local.instance_name
+    }
   }
 
   tags = {
@@ -195,6 +199,6 @@ resource "aws_instance" "analytics" {
   }
 
   lifecycle {
-    ignore_changes = [subnet_id]
+    ignore_changes = [subnet_id, tags, ami, root_block_device]
   }
 }

--- a/modules/services/analytics/variables.tf
+++ b/modules/services/analytics/variables.tf
@@ -10,6 +10,34 @@ variable "number_of_instances" {
 variable "instance_iteration" {
   default = 1
 }
+variable "instance_ebs_volume_type" {
+  description = "Type of EBS volumes attached to the EC2 instance."
+  default     = "gp2"
+}
+variable "instance_ebs_volume_size" {
+  description = "Size of EBS volumes attached to the EC2 instance (in GiB)."
+  default     = 50
+}
+variable "instance_ebs_iops" {
+  description = "Baseline input/output (I/O) performance of EBS volumes attached to the EC2 instance. Applicable only if `instance_ebs_volume_type` is set to \"gp3\"."
+  default     = 3000
+}
+variable "elasticsearch_instance_type" {
+  default     = "t2.small.elasticsearch"
+  description = "Instance type of ElasticSearch data nodes."
+}
+variable "elasticsearch_ebs_volume_type" {
+  description = "Type of EBS volumes attached to data nodes."
+  default     = "gp2"
+}
+variable "elasticsearch_ebs_volume_size" {
+  description = "Size of EBS volumes attached to data nodes (in GiB)."
+  default     = 10
+}
+variable "elasticsearch_ebs_iops" {
+  description = "Baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only if `elasticsearch_ebs_volume_type` is set to \"gp3\"."
+  default     = 3000
+}
 variable "lb_instance_indexes" {
   default = [0]
 }

--- a/modules/services/director/README.md
+++ b/modules/services/director/README.md
@@ -22,6 +22,9 @@ for the region you are going to use:
 - `image_id`: AWS Image ID for this instance (e.g. ami-0edab4XXXXXXXXX)
 - `instance_type`: Instance type, we recommend to use the smallest one (e.g. `t2.micro`)
 - `director_key_pair_name`: Name you given to the AWS Key Pair to be used to ssh into the director
+- `ebs_volume_type`: Type of EBS volumes attached to the instance. Defaults to "gp2".
+- `ebs_volume_size`: Size of EBS volumes attached to the instance (in GiB). Defaults to 8.
+- `ebs_iops`: Baseline input/output (I/O) performance of EBS volumes attached to the instance. Applicable only if `ebs_volume_type` is set to "gp3". Defaults to 3000.
 
 ## Output
 

--- a/modules/services/director/main.tf
+++ b/modules/services/director/main.tf
@@ -11,6 +11,15 @@ resource aws_instance director {
 
   key_name = var.director_key_pair_name
 
+  root_block_device {
+    volume_type = var.ebs_volume_type
+    volume_size = var.ebs_volume_size
+    iops        = var.ebs_volume_type == "gp3" ? var.ebs_iops : null
+    tags = {
+      Name = var.custom_instance_name == "" ? "edx-${var.environment}-director" : var.custom_instance_name
+    }
+  }
+
   tags = {
     Name = var.custom_instance_name == "" ? "edx-${var.environment}-director" : var.custom_instance_name
   }

--- a/modules/services/director/variables.tf
+++ b/modules/services/director/variables.tf
@@ -15,3 +15,16 @@ variable "specific_vpc_id" { default = "" }
 variable "specific_subnet_id" { default = "" }
 
 variable "custom_instance_name" { default = "" }
+
+variable "ebs_volume_type" {
+  description = "Type of EBS volumes attached to the instance."
+  default     = "gp2"
+}
+variable "ebs_volume_size" {
+  description = "Size of EBS volumes attached to the instance (in GiB)."
+  default     = 8
+}
+variable "ebs_iops" {
+  description = "Baseline input/output (I/O) performance of EBS volumes attached to the instance. Applicable only if `ebs_volume_type` is set to \"gp3\"."
+  default     = 3000
+}


### PR DESCRIPTION
This adds new variables to allow configuring EBS volumes for Director and Analytics. It allows migrating to [`gp3` volumes](https://aws.amazon.com/ebs/general-purpose/), which are cheaper and much faster than `gp2`.